### PR TITLE
refactor: remove `get_all_otus`

### DIFF
--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -25,13 +25,20 @@ class EventIndexError(Exception):
 
 
 class EventIndex:
-    """Maintains an index of event records for each OTU UUID in the repo"""
+    """Maintains an index of event records for each OTU UUID in the repo."""
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path) -> None:
+        """Initialize an event index.
+
+        If no directory exists at the given path, it will be created.
+
+        :param path: the path to the event index directory
+
+        """
         self.path = path
         self.path.mkdir(exist_ok=True)
 
-    def set(self, otu_id: UUID, event_ids: list[int], last_id: int):
+    def set(self, otu_id: UUID, event_ids: list[int], last_id: int) -> None:
         """Cache the event list for a given OTU.
 
         :param otu_id: an OTU ID

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -157,18 +157,13 @@ class Repo:
     def snapshot(self):
         """Create a snapshot using all the OTUs in the event store."""
         self._snapshotter.snapshot(
-            self.get_all_otus(ignore_cache=True),
+            self.iter_otus(ignore_cache=True),
             at_event=self.last_id,
             indent=True,
         )
 
-    def iter_otus(self) -> Generator[RepoOTU, None, None]:
+    def iter_otus(self, ignore_cache: bool = False) -> Generator[RepoOTU, None, None]:
         """Iterate over the OTUs in the snapshot."""
-        for otu_id in self._event_index.load():
-            yield self.get_otu(otu_id)
-
-    def get_all_otus(self, ignore_cache: bool = False) -> list[RepoOTU]:
-        """Retrieve all OTUs from the event store and return as a list."""
         if ignore_cache:
             event_index = defaultdict(list)
 
@@ -180,13 +175,8 @@ class Repo:
         else:
             event_index = self._event_index.load()
 
-        otus = []
-
         for otu_id in event_index:
-            if otu := self.get_otu(otu_id):
-                otus.append(otu)
-
-        return otus
+            yield self.get_otu(otu_id)
 
     def create_otu(
         self,

--- a/ref_builder/snapshotter/snapshotter.py
+++ b/ref_builder/snapshotter/snapshotter.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from uuid import UUID
@@ -127,7 +127,7 @@ class Snapshotter:
 
     def snapshot(
         self,
-        otus: list[RepoOTU],
+        otus: Iterable[RepoOTU],
         at_event: int | None = None,
         indent: bool = False,
     ):
@@ -135,6 +135,7 @@ class Snapshotter:
         options = orjson.OPT_INDENT_2 if indent else None
 
         _index = {}
+
         for otu in otus:
             self.cache_otu(otu, at_event=at_event, options=options)
             metadata = OTUKeys(

--- a/tests/snapshotter/test_snapshotter.py
+++ b/tests/snapshotter/test_snapshotter.py
@@ -11,7 +11,7 @@ def snapshotter(scratch_repo: Repo) -> Snapshotter:
 
 class TestSnapshotIndex:
     def test_otu_ids(self, scratch_repo: Repo, snapshotter: Snapshotter):
-        true_otu_ids = [otu.id for otu in scratch_repo.get_all_otus(ignore_cache=True)]
+        true_otu_ids = [otu.id for otu in scratch_repo.iter_otus(ignore_cache=True)]
 
         assert snapshotter.otu_ids
 
@@ -22,7 +22,7 @@ class TestSnapshotIndex:
 
     def test_load_by_id(self, snapshotter: Snapshotter, scratch_repo: Repo):
         """Test that we can load an OTU by its ID."""
-        otu_ids = [otu.id for otu in scratch_repo.get_all_otus(ignore_cache=True)]
+        otu_ids = [otu.id for otu in scratch_repo.iter_otus(ignore_cache=True)]
 
         for otu_id in otu_ids:
             assert snapshotter.load_by_id(otu_id).id == otu_id
@@ -33,7 +33,7 @@ class TestSnapshotIndex:
         snapshotter: Snapshotter,
     ):
         """Test that we can load an OTU by its taxid."""
-        taxids = [otu.taxid for otu in scratch_repo.get_all_otus(ignore_cache=True)]
+        taxids = [otu.taxid for otu in scratch_repo.iter_otus(ignore_cache=True)]
 
         for taxid in taxids:
             assert snapshotter.load_by_taxid(taxid).taxid == taxid
@@ -44,20 +44,18 @@ class TestSnapshotIndex:
         snapshotter: Snapshotter,
     ):
         """Test that we can load an OTU by its name."""
-        true_otu_names = [
-            otu.name for otu in scratch_repo.get_all_otus(ignore_cache=True)
-        ]
+        true_otu_names = [otu.name for otu in scratch_repo.iter_otus(ignore_cache=True)]
 
         for name in true_otu_names:
             assert snapshotter.load_by_name(name).name == name
 
     def test_accessions(self, scratch_repo: Repo, snapshotter: Snapshotter):
         true_accessions = set()
-        for otu in scratch_repo.get_all_otus(ignore_cache=True):
+
+        for otu in scratch_repo.iter_otus(ignore_cache=True):
             true_accessions.update(otu.accessions)
 
         assert true_accessions
-
         assert true_accessions == snapshotter.accessions
 
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -61,7 +61,7 @@ class TestCreateOTU:
 
         # Ensure only one OTU is present in the repository, and it matches the return
         # value of the creation function.
-        assert precached_repo.get_all_otus() == [otu]
+        assert list(precached_repo.iter_otus()) == [otu]
 
     def test_empty_fail(self, scratch_repo: Repo):
         with pytest.raises(ValueError):
@@ -78,7 +78,7 @@ class TestCreateOTU:
         precached_repo: Repo,
         snapshot: SnapshotAssertion,
     ):
-        assert not precached_repo.get_all_otus()
+        assert list(precached_repo.iter_otus()) == []
 
         otu = create_otu_with_schema(
             repo=precached_repo,
@@ -86,10 +86,8 @@ class TestCreateOTU:
             accessions=accessions,
         )
 
-        assert precached_repo.get_all_otus()
-
+        assert list(precached_repo.iter_otus())
         assert otu.schema is not None
-
         assert otu.dict() == snapshot(exclude=props("id"))
 
 
@@ -111,7 +109,7 @@ class TestCreateOTUCommands:
             accessions=accessions,
         )
 
-        otus = Repo(precached_repo.path).get_all_otus()
+        otus = list(Repo(precached_repo.path).iter_otus())
 
         assert len(otus) == 1
         otu = otus[0]
@@ -131,7 +129,7 @@ class TestCreateOTUCommands:
             autofill=True,
         )
 
-        otus = Repo(precached_repo.path).get_all_otus()
+        otus = list(Repo(precached_repo.path).iter_otus())
 
         assert len(otus) == 1
         otu = otus[0]
@@ -152,7 +150,7 @@ class TestCreateOTUCommands:
             autofill=True,
         )
 
-        otus = Repo(precached_repo.path).get_all_otus()
+        otus = list(Repo(precached_repo.path).iter_otus())
 
         assert len(otus) == 1
         otu = otus[0]
@@ -170,7 +168,7 @@ class TestAddSequences:
         accessions = ["DQ178614", "DQ178613", "DQ178610", "DQ178611"]
         run_add_sequences_command(345184, accessions, precached_repo.path)
 
-        for otu in precached_repo.get_all_otus():
+        for otu in precached_repo.iter_otus():
             assert otu.accessions == set(accessions)
 
             assert otu.dict() == snapshot(exclude=props("id", "isolates"))

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -429,7 +429,7 @@ class TestRetrieveOTU:
         assert initialized_repo.get_otu(uuid.uuid4()) is None
 
     def test_get_accessions(self, initialized_repo: Repo):
-        otu = list(initialized_repo.get_all_otus(ignore_cache=True))[0]
+        otu = next(initialized_repo.iter_otus(ignore_cache=True))
 
         assert otu.accessions == {"TMVABC"}
 
@@ -449,7 +449,7 @@ class TestRetrieveOTU:
             "ACGTGGAGAGACC",
         )
 
-        otu = list(initialized_repo.get_all_otus(ignore_cache=True))[0]
+        otu = next(initialized_repo.iter_otus(ignore_cache=True))
 
         assert otu.accessions == {"TMVABC", "TMVABCB"}
 
@@ -462,6 +462,7 @@ class TestRetrieveOTU:
             "B",
             IsolateNameType.ISOLATE,
         )
+
         initialized_repo.create_sequence(
             otu.id,
             isolate_b.id,
@@ -482,7 +483,8 @@ class TestRetrieveOTU:
 
 class TestGetIsolate:
     def test_get_isolate(self, initialized_repo: Repo):
-        otu = list(initialized_repo.get_all_otus(ignore_cache=True))[0]
+        """Test that getting an isolate returns the expected ``RepoIsolate`` object."""
+        otu = next(initialized_repo.iter_otus(ignore_cache=True))
 
         isolate_ids = {isolate.id for isolate in otu.isolates}
 
@@ -490,7 +492,8 @@ class TestGetIsolate:
             assert otu.get_isolate(isolate_id) in otu.isolates
 
     def test_get_isolate_id_by_name(self, initialized_repo: Repo):
-        otu = initialized_repo.get_all_otus()[0]
+        """Test that getting an isolate ID by name returns the expected ID."""
+        otu = next(initialized_repo.iter_otus())
 
         isolate_ids = {isolate.id for isolate in otu.isolates}
 


### PR DESCRIPTION
* Remove the `Repo.get_all_otus()` method.
* Bring `ignore_cache` ability into `iter_otus`.
* Move all `get_all_otus` usages to `iter_otus`.

