### PR TITLE
Add commands for showing OTU data

### DIFF
--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -135,7 +135,7 @@ def otu_update(debug: bool, ignore_cache: bool, path: Path, taxid: int) -> None:
 
 
 @otu.command(name="get")
-@click.argument("IDENTIFIER", type=int)
+@click.argument("IDENTIFIER", type=str)
 @path_option
 def otu_get(identifier: str, path: Path) -> int:
     """Get an OTU by its Taxonomy ID."""

--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -1,3 +1,5 @@
+"""Command-line interface for reference builder."""
+
 import glob
 import sys
 from pathlib import Path
@@ -58,11 +60,11 @@ def init(data_type: DataType, name: str, organism: str, path: Path) -> None:
 
 
 @entry.group()
-def otu():
-    """Manage OTUs"""
+def otu() -> None:
+    """Manage OTUs."""
 
 
-@otu.command()
+@otu.command(name="create")
 @click.argument("TAXID", type=int)
 @click.argument(
     "accessions_",
@@ -74,14 +76,15 @@ def otu():
 @ignore_cache_option
 @debug_option
 @path_option
-def create(
+def otu_create(
     debug: bool,
     ignore_cache: bool,
     path: Path,
     taxid: int,
     accessions_: list[str],
     autofill: bool,
-):
+) -> None:
+    """Create a new OTU for the given Taxonomy ID and accessions."""
     configure_logger(debug)
 
     repo = Repo(path)
@@ -110,23 +113,25 @@ def create(
         update_otu(repo, new_otu, ignore_cache=ignore_cache)
 
 
-@otu.command()
+@otu.command(name="update")
 @click.argument("TAXID", type=int)
 @debug_option
 @ignore_cache_option
 @path_option
-def update(debug: bool, ignore_cache: bool, path: Path, taxid: int):
+def otu_update(debug: bool, ignore_cache: bool, path: Path, taxid: int) -> None:
+    """Update an existing OTU with the latest data from NCBI."""
     configure_logger(debug)
 
     repo = Repo(path)
 
-    otu = repo.get_otu_by_taxid(taxid)
-    if otu is None:
+    otu_ = repo.get_otu_by_taxid(taxid)
+
+    if otu_ is None:
         click.echo(f"OTU not found for Taxonomy ID {taxid}.", err=True)
         click.echo(f'Run "virtool otu create {taxid} --autofill" instead.')
         sys.exit(1)
 
-    update_otu(repo, otu, ignore_cache=ignore_cache)
+    update_otu(repo, otu_, ignore_cache=ignore_cache)
 
 
 @otu.command(name="get")
@@ -198,7 +203,7 @@ def create_sequence(
 
 
 @entry.group()
-def legacy():
+def legacy() -> None:
     """Validate and convert legacy references."""
 
 
@@ -209,7 +214,7 @@ def legacy():
     required=True,
     type=click.Path(exists=True, file_okay=False, path_type=Path),
 )
-def precache(path: Path):
+def precache(path: Path) -> None:
     """Pre-cache all accessions in a legacy reference repository."""
     ncbi = NCBIClient(path / ".migration_cache", False)
 
@@ -270,7 +275,7 @@ def reformat(path: Path) -> None:
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="the path to a legacy reference directory",
 )
-def validate(debug: bool, fix: bool, limit: int, no_ok: bool, path: Path):
+def validate(debug: bool, fix: bool, limit: int, no_ok: bool, path: Path) -> None:
     """Validate a legacy reference repository."""
     configure_logger(debug)
 
@@ -305,6 +310,6 @@ def validate(debug: bool, fix: bool, limit: int, no_ok: bool, path: Path):
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="the path to the reference repository",
 )
-def build(output_path: Path, path: Path, indent: bool, version: str):
+def build(output_path: Path, path: Path, indent: bool, version: str) -> None:
     """Build a Virtool reference.json file from a reference repository."""
     build_json(indent, output_path, path, version)

--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -142,7 +142,7 @@ def otu_get(identifier: str, path: Path) -> int:
     try:
         identifier = int(identifier)
         otu_ = Repo(path).get_otu_by_taxid(identifier)
-    except TypeError:
+    except ValueError:
         otu_ = Repo(path).get_otu(UUID(identifier))
 
     if otu_ is None:

--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -1,10 +1,12 @@
 import glob
 import sys
 from pathlib import Path
+from uuid import UUID
 
 import click
 
 from ref_builder.build import build_json
+from ref_builder.console import print_otu, print_otu_list
 from ref_builder.legacy.utils import iter_legacy_otus
 from ref_builder.legacy.validate import validate_legacy_repo
 from ref_builder.logging import configure_logger
@@ -127,9 +129,36 @@ def update(debug: bool, ignore_cache: bool, path: Path, taxid: int):
     update_otu(repo, otu, ignore_cache=ignore_cache)
 
 
+@otu.command(name="get")
+@click.argument("IDENTIFIER", type=int)
+@path_option
+def otu_get(identifier: str, path: Path) -> int:
+    """Get an OTU by its Taxonomy ID."""
+    try:
+        identifier = int(identifier)
+        otu_ = Repo(path).get_otu_by_taxid(identifier)
+    except TypeError:
+        otu_ = Repo(path).get_otu(UUID(identifier))
+
+    if otu_ is None:
+        click.echo("No OTU found.", err=True)
+        return 1
+
+    print_otu(otu_)
+
+    return 0
+
+
+@otu.command(name="list")
+@path_option
+def otu_list(path: Path) -> None:
+    """List all OTUs in the repository."""
+    print_otu_list(Repo(path).iter_otus())
+
+
 @entry.group()
-def sequences():
-    """Manage sequences"""
+def sequences() -> None:
+    """Manage sequences."""
 
 
 @sequences.command(name="create")

--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -99,11 +99,11 @@ def print_otu_list(otus: Iterable[RepoOTU]) -> None:
 
     table.add_column("NAME")
     table.add_column("ACRONYM")
-    table.add_column("ID")
     table.add_column("TAXID")
+    table.add_column("ID")
 
     for otu in otus:
-        table.add_row(otu.name, otu.acronym, str(otu.id), str(otu.taxid))
+        table.add_row(otu.name, otu.acronym, str(otu.taxid), str(otu.id))
 
     console.print(table)
 

--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -16,7 +16,7 @@ def print_otu(otu: RepoOTU) -> None:
     :param otu: The OTU to print.
 
     """
-    console.print(f"[bold][underline]OTU {otu.name}[/bold][/underline]")
+    console.print(f"[bold][underline]{otu.name}[/bold][/underline]")
     console.line()
 
     table = Table(

--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -1,0 +1,111 @@
+from collections.abc import Iterable
+
+import rich.console
+from rich.table import Table
+
+from ref_builder.resources import RepoOTU
+
+
+def _render_taxonomy_id_link(taxid: int) -> str:
+    return f"[link=https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id={taxid}]{taxid}[/link]"
+
+
+def print_otu(otu: RepoOTU) -> None:
+    """Print the details for an OTU to the console.
+
+    :param otu: The OTU to print.
+
+    """
+    console.print(f"[bold][underline]OTU {otu.name}[/bold][/underline]")
+    console.line()
+
+    table = Table(
+        box=None,
+        show_header=False,
+    )
+
+    table.add_row("[bold]ACRONYM[/bold]", otu.acronym)
+    table.add_row("[bold]ID[/bold]", str(otu.id))
+
+    if otu.legacy_id:
+        table.add_row("[bold]LEGACY ID[/bold]", otu.legacy_id)
+
+    table.add_row("[bold]TAXID[/bold]", _render_taxonomy_id_link(otu.taxid))
+
+    max_accession_length = max(
+        len(sequence.accession)
+        for isolate in otu.isolates
+        for sequence in isolate.sequences
+    )
+
+    max_segment_name_length = max(len(segment.name) for segment in otu.schema.segments)
+
+    console.print(table)
+
+    console.line()
+    console.print("[bold]SCHEMA[/bold]")
+    console.line()
+
+    schema_table = Table(box=None)
+
+    schema_table.add_column("SEGMENT")
+    schema_table.add_column("REQUIRED")
+    schema_table.add_column("LENGTH")
+
+    for segment in otu.schema.segments:
+        schema_table.add_row(
+            segment.name,
+            "[red]Yes[/red]" if segment.required else "[grey]No[/grey]",
+            str(segment.length),
+        )
+
+    console.print(schema_table)
+
+    console.line()
+    console.print("[bold]ISOLATES[/bold]")
+
+    for isolate in otu.isolates:
+        console.line()
+        console.print(str(isolate.name))
+        console.line()
+
+        isolate_table = Table(
+            box=None,
+        )
+
+        isolate_table.add_column("ACCESSION", width=max_accession_length)
+        isolate_table.add_column("SEGMENT", min_width=max_segment_name_length)
+        isolate_table.add_column("DEFINITION")
+
+        for sequence in sorted(isolate.sequences, key=lambda s: s.accession):
+            isolate_table.add_row(
+                sequence.accession,
+                sequence.segment,
+                sequence.definition,
+            )
+
+        console.print(isolate_table)
+
+
+def print_otu_list(otus: Iterable[RepoOTU]) -> None:
+    """Print a list of OTUs to the console.
+
+    :param otus: The OTUs to print.
+
+    """
+    table = Table(
+        box=None,
+    )
+
+    table.add_column("NAME")
+    table.add_column("ACRONYM")
+    table.add_column("ID")
+    table.add_column("TAXID")
+
+    for otu in otus:
+        table.add_row(otu.name, otu.acronym, str(otu.id), str(otu.taxid))
+
+    console.print(table)
+
+
+console = rich.console.Console()

--- a/ref_builder/legacy/repo.py
+++ b/ref_builder/legacy/repo.py
@@ -2,7 +2,8 @@
 
 from pathlib import Path
 
-from ref_builder.legacy.utils import console, iter_legacy_otus
+from ref_builder.console import console
+from ref_builder.legacy.utils import iter_legacy_otus
 
 
 def check_unique_accessions(path: Path) -> None:

--- a/ref_builder/legacy/utils.py
+++ b/ref_builder/legacy/utils.py
@@ -6,14 +6,11 @@ from random import choice
 from string import ascii_letters, ascii_lowercase, digits
 
 import orjson
-import rich.console
 from pydantic_core import ErrorDetails
 
 from ref_builder.legacy.models import LegacyIsolateSource, LegacySourceType
 from ref_builder.ncbi.client import NCBIClient
 from ref_builder.ncbi.models import NCBIGenbank
-
-console = rich.console.Console()
 
 
 class HandleErrorContext:

--- a/ref_builder/legacy/validate.py
+++ b/ref_builder/legacy/validate.py
@@ -12,6 +12,7 @@ from rich.padding import Padding
 from rich.table import Table
 from structlog import get_logger
 
+from ref_builder.console import console
 from ref_builder.legacy.handlers import (
     handle_enum,
     handle_int_type,
@@ -32,7 +33,6 @@ from ref_builder.legacy.utils import (
     ErrorHandledResult,
     HandleErrorContext,
     build_legacy_otu,
-    console,
     replace_otu,
 )
 from ref_builder.ncbi.client import NCBIClient

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -75,8 +75,6 @@ class Repo:
         self.path = path
         """The path to the repo directory."""
 
-        logger.info("Loading repository")
-
         self.cache_path = self.path / ".cache"
         """The path to the cache subdirectory."""
 
@@ -99,8 +97,6 @@ class Repo:
         if not self._snapshotter.otu_ids:
             logger.debug("No snapshot data found. Building new snapshot...")
             self.snapshot()
-
-        logger.info("Finished loading repository", event_count=self.last_id)
 
     @classmethod
     def new(cls, data_type: DataType, name: str, path: Path, organism: str):

--- a/ref_builder/snapshotter/snapshotter.py
+++ b/ref_builder/snapshotter/snapshotter.py
@@ -247,8 +247,6 @@ class Snapshotter:
 
             _index[otu_id] = OTUKeys(**index_dict[key])
 
-        logger.debug("Loaded Snapshot index", loaded_index=index_dict)
-
         return _index
 
     def _update_index(self):

--- a/ref_builder/utils.py
+++ b/ref_builder/utils.py
@@ -54,6 +54,9 @@ class IsolateName:
     value: str
     """The name of this subcategory."""
 
+    def __str__(self) -> str:
+        return f"{self.type.value.capitalize()} {self.value}"
+
 
 def format_json(path: Path) -> None:
     """Format the JSON file at `path` in place.

--- a/tests/ncbi/test_ncbi_client.py
+++ b/tests/ncbi/test_ncbi_client.py
@@ -78,7 +78,10 @@ class TestClientFetchGenbank:
         [["AB017503", "AB017504", "MH200607", "MK431779", "NC_003355"]],
     )
     def test_fetch_partially_cached_genbank_records(
-        self, accessions: list[str], empty_client, test_files_path
+        self,
+        accessions: list[str],
+        empty_client,
+        test_files_path,
     ):
         ncbi_cache_files = test_files_path / "cache_test"
         for accession in ("AB017504", "MH200607"):
@@ -101,7 +104,7 @@ class TestClientFetchGenbank:
             assert accession in cache_contents
 
     @pytest.mark.ncbi()
-    async def test_fetch_accessions_fail(self, scratch_ncbi_client):
+    def test_fetch_accessions_fail(self, scratch_ncbi_client: NCBIClient):
         records = scratch_ncbi_client.fetch_genbank_records(["friday", "paella", "111"])
 
         assert not records
@@ -131,7 +134,7 @@ class TestClientFetchRawGenbank:
             ["friday", "MT240513", "MT240490"],
         ],
     )
-    async def test_fetch_raw_via_accessions_partial(self, accessions: list[str]):
+    def test_fetch_raw_via_accessions_partial(self, accessions: list[str]):
         records = NCBIClient.fetch_unvalidated_genbank_records(accessions)
 
         assert len(records) == len(accessions) - 1
@@ -168,7 +171,6 @@ def test_fetch_records_by_taxid(taxid: int, empty_client, snapshot: SnapshotAsse
 
 class TestClientFetchTaxonomy:
     @pytest.mark.ncbi()
-    @pytest.mark.flaky(reruns=3, reruns_delay=3, only_rerun=SERVER_ERRORS)
     @pytest.mark.parametrize("taxid", [438782, 1198450, 1016856])
     def test_fetch_taxonomy_from_ncbi(
         self,
@@ -185,7 +187,6 @@ class TestClientFetchTaxonomy:
         } == snapshot
 
     @pytest.mark.ncbi()
-    @pytest.mark.flaky(reruns=3, reruns_delay=3, only_rerun=SERVER_ERRORS)
     @pytest.mark.parametrize("taxid", [1000000000000, 99999999])
     def test_fetch_taxonomy_from_ncbi_fail(self, taxid: int, empty_client):
         taxonomy = empty_client.fetch_taxonomy_record(taxid)
@@ -216,7 +217,7 @@ class TestClientFetchTaxonomy:
         ("Rhynchosia golden mosaic virus", 117198),
     ],
 )
-async def test_fetch_taxonomy_by_name(name: str, taxid: int):
+def test_fetch_taxonomy_by_name(name: str, taxid: int):
     assert NCBIClient.fetch_taxonomy_id_by_name(name) == taxid
 
 
@@ -235,7 +236,7 @@ async def test_fetch_taxonomy_by_name(name: str, taxid: int):
         ),
     ],
 )
-async def test_fetch_spelling(misspelled: str, expected: str):
+def test_fetch_spelling(misspelled: str, expected: str):
     taxon_name = NCBIClient.fetch_spelling(name=misspelled)
 
     assert taxon_name == expected


### PR DESCRIPTION
* Add commands to list OTUs and show details of a single OTU.
* Clean up CLI module, resolving most Ruff linter errors.
* Remove flaky mark from NCBI tests. The package is not installed and we should be ensuring these tests always pass by making the code more resilient.
* Remove unused `async` from NCBI tests.
* Remove some log calls. We need to rethink this so it doesn't clutter the output. One idea is logging to stderr or writing log files.

Output of `ref-builder otu list`:
```text
 NAME                    ACRONYM  ID                                    TAXID
 Abaca bunchy top virus  ABTV     586ba010-4121-48a5-bf0c-f4462cc07b0c  438782
 Abutilon Brazil virus   AbBV     12e98766-2870-4334-a9cd-1705fd8d2066  665102
```

Output of `ref-builder otu get`:
```text
Abaca bunchy top virus

 ACRONYM    ABTV
 ID         586ba010-4121-48a5-bf0c-f4462cc07b0c
 LEGACY ID  c93ec9a9
 TAXID      438782

SCHEMA

 SEGMENT  REQUIRED  LENGTH
 DNA N    Yes       1090
 DNA U3   Yes       1057
 DNA S    Yes       1087
 DNA M    Yes       1074
 DNA C    Yes       1015
 DNA R    Yes       1099

ISOLATES

Isolate Q767

 ACCESSION    SEGMENT  DEFINITION
 NC_010314.1  DNA N    Abaca bunchy top virus DNA-N, complete genome
 NC_010315.1  DNA U3   Abaca bunchy top virus segment 2, complete sequence
 NC_010316.1  DNA S    Abaca bunchy top virus DNA-S, complete genome
 NC_010317.1  DNA M    Abaca bunchy top virus DNA-M, complete genome
 NC_010318.1  DNA C    Abaca bunchy top virus DNA-C, complete sequence
 NC_010319.1  DNA R    Abaca bunchy top virus DNA-R, complete genome

Isolate Q1108

 ACCESSION    SEGMENT  DEFINITION
 EF546802.1   DNA N    Abaca bunchy top virus isolate Q1108 segment DNA-N, complete sequence
 EF546803.1   DNA U3   Abaca bunchy top virus isolate Q1108 segment DNA-U3, complete sequence
 EF546804.1   DNA S    Abaca bunchy top virus isolate Q1108 segment DNA-S, complete sequence
 EF546805.1   DNA M    Abaca bunchy top virus isolate Q1108 segment DNA-M, complete sequence
 EF546806.1   DNA C    Abaca bunchy top virus isolate Q1108 segment DNA-C, complete sequence
 EF546807.1   DNA R    Abaca bunchy top virus isolate Q1108 segment DNA-R, complete sequence
```
