### PR TITLE
Add SetReprIsolate

### DIFF
--- a/ref_builder/events.py
+++ b/ref_builder/events.py
@@ -167,3 +167,14 @@ class CreateSchema(Event):
 
     data: CreateSchemaData
     query: OTUQuery
+
+
+class SetReprIsolateData(EventData):
+    isolate_id: UUID4
+
+
+class SetReprIsolate(Event):
+    """A representative isolate setting event."""
+
+    data: SetReprIsolateData
+    query: OTUQuery

--- a/ref_builder/events.py
+++ b/ref_builder/events.py
@@ -94,7 +94,6 @@ class CreateOTUData(EventData):
     legacy_id: str | None
     name: str
     taxid: int
-    rep_isolate: UUID4 | None
     otu_schema: OTUSchema | None = Field(None, alias="schema")
 
 

--- a/ref_builder/otu.py
+++ b/ref_builder/otu.py
@@ -87,9 +87,7 @@ def create_otu_with_schema(
 
     otu.add_isolate(isolate)
 
-    repr_isolate = repo.set_repr_isolate(otu_id=otu.id, isolate_id=isolate.id)
-
-    otu.repr_isolate = repr_isolate
+    otu.repr_isolate = repo.set_repr_isolate(otu_id=otu.id, isolate_id=isolate.id)
 
     for record in records:
         sequence = repo.create_sequence(

--- a/ref_builder/otu.py
+++ b/ref_builder/otu.py
@@ -87,6 +87,10 @@ def create_otu_with_schema(
 
     otu.add_isolate(isolate)
 
+    repr_isolate = repo.set_repr_isolate(otu_id=otu.id, isolate_id=isolate.id)
+
+    otu.repr_isolate = repr_isolate
+
     for record in records:
         sequence = repo.create_sequence(
             otu_id=otu.id,

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -43,6 +43,7 @@ from ref_builder.events import (
     OTUQuery,
     RepoQuery,
     SequenceQuery,
+    SetReprIsolate,
 )
 from ref_builder.index import EventIndex, EventIndexError
 from ref_builder.models import Molecule
@@ -586,6 +587,8 @@ class EventStore:
                     return CreateSequence(**loaded)
                 case "CreateSchema":
                     return CreateSchema(**loaded)
+                case "SetReprIsolate":
+                    return SetReprIsolate(**loaded)
                 case "ExcludeAccession":
                     return ExcludeAccession(**loaded)
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -199,7 +199,6 @@ class Repo:
                 legacy_id=legacy_id,
                 name=name,
                 schema=schema,
-                rep_isolate=None,
                 taxid=taxid,
             ),
             OTUQuery(otu_id=otu_id),

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -43,7 +43,7 @@ from ref_builder.events import (
     OTUQuery,
     RepoQuery,
     SequenceQuery,
-    SetReprIsolate,
+    SetReprIsolate, SetReprIsolateData,
 )
 from ref_builder.index import EventIndex, EventIndexError
 from ref_builder.models import Molecule
@@ -389,6 +389,9 @@ class Repo:
                     molecule=event.data.molecule,
                     segments=event.data.segments,
                 )
+
+            elif isinstance(event, SetReprIsolate):
+                otu.repr_isolate = event.data.isolate_id
 
             elif isinstance(event, CreateIsolate):
                 otu.add_isolate(

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -322,6 +322,18 @@ class Repo:
 
         return self.get_otu(otu_id).schema
 
+    def set_repr_isolate(self, otu_id: uuid.UUID, isolate_id: uuid.UUID) -> uuid.UUID:
+        """Set the representative isolate for an OTU"""
+        otu = self.get_otu(otu_id)
+
+        self._event_store.write_event(
+            SetReprIsolate,
+            SetReprIsolateData(isolate_id=isolate_id),
+            OTUQuery(otu_id=otu.id)
+        )
+
+        return self.get_otu(otu_id).repr_isolate
+
     def exclude_accession(self, otu_id: uuid.UUID, accession: str) -> None:
         """Exclude an accession for an OTU.
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -59,15 +59,6 @@ from ref_builder.utils import DataType, IsolateName, IsolateNameType, pad_zeroes
 logger = get_logger("repo")
 
 
-OTU_EVENT_TYPES = (
-    CreateOTU,
-    CreateIsolate,
-    CreateSchema,
-    CreateSequence,
-    ExcludeAccession,
-)
-
-
 class Repo:
     """An event-sourced repository."""
 
@@ -452,7 +443,7 @@ class Repo:
 
         for event in self._event_store.iter_events(start=at_event + 1):
             if (
-                type(event) in OTU_EVENT_TYPES
+                issubclass(type(event.query), OTUQuery)
                 and event.query.model_dump().get("otu_id") == otu_id
             ):
                 if event.id in event_ids:

--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -283,7 +283,10 @@ class RepoOTU:
         """Return a shorthand representation of the OTU's contents."""
         return (
             f"EventSourcedRepoOTU(id='{self.id}', taxid='{self.taxid}', "
-            f"name={self.name}, accessions={list(self.accessions)})"
+            f"name={self.name}, "
+            f"schema={self.schema}, "
+            f"repr_isolate={self.repr_isolate}, "
+            f"accessions={list(self.accessions)})"
         )
 
     def add_isolate(self, isolate: RepoIsolate) -> None:
@@ -340,6 +343,7 @@ class RepoOTU:
             "id": self.id,
             "acronym": self.acronym,
             "excluded_accessions": list(self.excluded_accessions),
+            "repr_isolate": self.repr_isolate,
             "legacy_id": self.legacy_id,
             "name": self.name,
             "schema": self.schema.model_dump() if self.schema is not None else None,

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -6,6 +6,7 @@
     ]),
     'legacy_id': None,
     'name': 'Cabbage leaf curl Jamaica virus',
+    'repr_isolate': None,
     'schema': None,
     'taxid': 345184,
   })

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -88,7 +88,9 @@ class TestCreateOTU:
 
         assert list(precached_repo.iter_otus())
         assert otu.schema is not None
-        assert otu.dict() == snapshot(exclude=props("id"))
+        assert otu.repr_isolate is not None
+
+        assert otu.dict() == snapshot(exclude=props("id", "repr_isolate"))
 
 
 class TestCreateOTUCommands:
@@ -114,7 +116,7 @@ class TestCreateOTUCommands:
         assert len(otus) == 1
         otu = otus[0]
 
-        assert otu.dict() == snapshot(exclude=props("id", "isolates"))
+        assert otu.dict() == snapshot(exclude=props("id", "isolates", "repr_isolate"))
 
     @pytest.mark.ncbi()
     def test_autofill(
@@ -134,7 +136,7 @@ class TestCreateOTUCommands:
         assert len(otus) == 1
         otu = otus[0]
 
-        assert otu.dict() == snapshot(exclude=props("id", "isolates"))
+        assert otu.dict() == snapshot(exclude=props("id", "isolates", "repr_isolate"))
         assert otu.accessions
 
     @pytest.mark.ncbi()
@@ -171,7 +173,7 @@ class TestAddSequences:
         for otu in precached_repo.iter_otus():
             assert otu.accessions == set(accessions)
 
-            assert otu.dict() == snapshot(exclude=props("id", "isolates"))
+            assert otu.dict() == snapshot(exclude=props("id", "isolates", "repr_isolate"))
 
             for isolate in otu.isolates:
                 assert isolate.dict() == snapshot(exclude=props("id", "sequences"))
@@ -195,7 +197,7 @@ class TestUpdateOTU:
         otu = precached_repo.get_otu(otu.id)
 
         assert [otu.dict() for otu in precached_repo.iter_otus()] == snapshot(
-            exclude=props("id", "isolates"),
+            exclude=props("id", "isolates", "repr_isolate"),
         )
 
         assert otu.accessions == {

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -128,7 +128,6 @@ class TestCreateOTU:
                 "acronym": "TMV",
                 "legacy_id": "abcd1234",
                 "name": "Tobacco mosaic virus",
-                "rep_isolate": None,
                 "schema": {
                     "molecule": {
                         "strandedness": "single",


### PR DESCRIPTION
* Add `SetReprIsolate` event
* Add `test_otu_model_adherence` to monitor missing fields in `OTUSnapshotOTU`
* Add `.repr_isolate` and `.excluded_accessions` fields to OTU snapshots
* Fix missing taxid existence check in `create_otu_with_schema()`