### PR TITLE
ECO-73: Replace individual sequence addition with isolate addition

### DIFF
--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -18,7 +18,7 @@ from ref_builder.options import debug_option, ignore_cache_option, path_option
 from ref_builder.otu import (
     add_isolate,
     create_otu,
-    update_otu,
+    auto_update_otu,
 )
 from ref_builder.repo import Repo
 from ref_builder.utils import DataType, format_json
@@ -105,7 +105,7 @@ def otu_create(
         sys.exit(1)
 
     if autofill:
-        update_otu(repo, new_otu, ignore_cache=ignore_cache)
+        auto_update_otu(repo, new_otu, ignore_cache=ignore_cache)
 
 
 @otu.command(name="get")
@@ -177,7 +177,7 @@ def otu_autoupdate(ctx, debug: bool, ignore_cache: bool) -> None:
         click.echo(f'Run "virtool otu create {taxid} --autofill" instead.')
         sys.exit(1)
 
-    update_otu(repo, otu_, ignore_cache=ignore_cache)
+    auto_update_otu(repo, otu_, ignore_cache=ignore_cache)
 
 
 @update.command(name="isolate")

--- a/ref_builder/otu.py
+++ b/ref_builder/otu.py
@@ -217,9 +217,7 @@ def create_isolate(
 ):
     """Take a list of records that make up a new isolate and add them to the OTU."""
     isolate_logger = structlog.get_logger("otu.isolate").bind(
-        accessions=sorted([str(record.accession) for record in records]),
         isolate_name=str(isolate_name),
-        otu_id=str(otu.id),
         otu_name=otu.name,
         taxid=otu.taxid,
     )
@@ -246,6 +244,7 @@ def create_isolate(
     isolate_logger.info(
         f"{isolate.name} created",
         isolate_id=str(isolate.id),
+        sequences=sorted([str(record.accession) for record in records]),
     )
 
     return isolate

--- a/ref_builder/otu.py
+++ b/ref_builder/otu.py
@@ -111,7 +111,7 @@ def create_otu(
     return otu
 
 
-def update_otu(
+def auto_update_otu(
     repo: Repo,
     otu: RepoOTU,
     ignore_cache: bool = False,

--- a/ref_builder/otu.py
+++ b/ref_builder/otu.py
@@ -171,7 +171,11 @@ def add_isolate(
     accessions: list[str],
     ignore_cache: bool = False
 ) -> None:
-    """Take a list of accessions that make up a new isolate and add them to the OTU."""
+    """Take a list of accessions that make up a new isolate and a new isolate to the OTU.
+
+    Download the GenBank records, categorize into an isolate bin and pass the isolate name
+    and records to the add method.
+    """
     ncbi = NCBIClient(ignore_cache)
 
     otu_logger = logger.bind(taxid=otu.taxid, otu_id=str(otu.id), name=otu.name)
@@ -215,7 +219,8 @@ def create_isolate(
     isolate_name: IsolateName,
     records: list[NCBIGenbank],
 ):
-    """Take a list of records that make up a new isolate and add them to the OTU."""
+    """Take a list of GenBank records that make up a new isolate
+    and add them to the OTU."""
     isolate_logger = structlog.get_logger("otu.isolate").bind(
         isolate_name=str(isolate_name),
         otu_name=otu.name,

--- a/ref_builder/otu.py
+++ b/ref_builder/otu.py
@@ -178,6 +178,11 @@ def add_isolate(
             sequence=record.sequence,
         )
 
+    otu_logger.info(
+        f"{isolate.name} created",
+        accessions=sorted([str(accession) for accession in isolate_records.keys()]),
+    )
+
     return isolate
 
 

--- a/ref_builder/otu.py
+++ b/ref_builder/otu.py
@@ -129,9 +129,9 @@ def update_otu(
 def add_isolate(
     repo: Repo,
     otu: RepoOTU,
-    accessions: list,
-    ignore_cache: bool = False,
-):
+    accessions: list[str],
+    ignore_cache: bool = False
+) -> None:
     """Take a list of accessions that make up a new isolate and add them to the OTU."""
     ncbi = NCBIClient(ignore_cache)
 
@@ -149,6 +149,17 @@ def add_isolate(
     )
 
     records = ncbi.fetch_genbank_records(fetch_list)
+
+    return create_isolate(repo, otu, records)
+
+
+def create_isolate(
+    repo: Repo,
+    otu: RepoOTU,
+    records: list[NCBIGenbank],
+):
+    """Take a list of records that make up a new isolate and add them to the OTU."""
+    otu_logger = logger.bind(taxid=otu.taxid, otu_id=str(otu.id), name=otu.name)
 
     record_bins = group_genbank_records_by_isolate(records)
     if len(record_bins) != 1:

--- a/ref_builder/otu.py
+++ b/ref_builder/otu.py
@@ -247,6 +247,10 @@ def add_sequences(
     otu_logger.info("No new sequences added to OTU")
 
 
+def exclude_accessions_from_otu(repo, otu, accessions):
+    for accession in accessions:
+        repo.exclude_accession(otu.id, accession)
+
 def add_schema_from_accessions(
     repo: Repo,
     taxid: int,

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -366,7 +366,7 @@ class Repo:
 
         return None
 
-    def get_otu_by_taxid(self, taxid: int) -> UUID | None:
+    def get_otu_by_taxid(self, taxid: int) -> RepoOTU | None:
         """Return the OTU with the given ``taxid``.
 
         If no OTU is found, return None.

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -94,28 +94,33 @@
       'excluded_accessions': list([
       ]),
       'legacy_id': None,
-      'name': 'Cabbage leaf curl Jamaica virus',
+      'name': 'Apple rubbery wood virus 1',
       'schema': dict({
         'molecule': dict({
-          'strandedness': 'double',
-          'topology': 'circular',
-          'type': 'DNA',
+          'strandedness': 'single',
+          'topology': 'linear',
+          'type': 'RNA',
         }),
         'multipartite': True,
         'segments': list([
           dict({
-            'length': 2575,
-            'name': 'DNA-A',
+            'length': 7219,
+            'name': 'L',
             'required': True,
           }),
           dict({
-            'length': 2494,
-            'name': 'DNA-B',
+            'length': 1613,
+            'name': 'M',
+            'required': True,
+          }),
+          dict({
+            'length': 1291,
+            'name': 'S',
             'required': True,
           }),
         ]),
       }),
-      'taxid': 345184,
+      'taxid': 2164102,
     }),
   ])
 # ---

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -5,7 +5,6 @@ import pytest
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
 
-import otu
 from ref_builder.otu import create_otu, update_otu, add_isolate
 from ref_builder.repo import Repo
 
@@ -33,17 +32,6 @@ def run_create_otu_command(
 def run_update_otu_command(taxid: int, path: Path):
     subprocess.run(
         ["ref-builder", "otu", "update"] + [str(taxid)] + ["--path", str(path)],
-        check=False,
-    )
-
-
-def run_add_sequences_command(taxid: int, accessions: list[str], path: Path):
-    subprocess.run(
-        ["ref-builder"]
-        + ["sequences", "add"]
-        + accessions
-        + ["--taxid", str(taxid)]
-        + ["--path", str(path)],
         check=False,
     )
 
@@ -204,30 +192,6 @@ class TestAddIsolate:
 
 
 
-
-class TestAddSequences:
-    def test_ok(
-        self,
-        precached_repo: Repo,
-        snapshot: SnapshotAssertion,
-    ):
-        accessions = ["DQ178614", "DQ178613", "DQ178610", "DQ178611"]
-        run_add_sequences_command(345184, accessions, precached_repo.path)
-
-        for otu in precached_repo.iter_otus():
-            assert otu.accessions == set(accessions)
-
-            assert otu.dict() == snapshot(
-                exclude=props("id", "isolates", "repr_isolate"),
-            )
-
-            for isolate in otu.isolates:
-                assert isolate.dict() == snapshot(exclude=props("id", "sequences"))
-
-                for accession in sorted(isolate.accessions):
-                    assert isolate.get_sequence_by_accession(
-                        accession,
-                    ).dict() == snapshot(exclude=props("id"))
 
 @pytest.mark.ncbi()
 class TestUpdateOTU:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -184,13 +184,11 @@ class TestAddIsolate:
 
         isolate = add_isolate(precached_repo, otu, isolate_2_accessions)
 
-        assert isolate.accessions == set(isolate_2_accessions)
-
         otu = precached_repo.get_otu_by_taxid(345184)
 
         assert otu.accessions == set(isolate_1_accessions).union(set(isolate_2_accessions))
 
-
+        assert otu.get_isolate(isolate.id).accessions == set(isolate_2_accessions)
 
 
 @pytest.mark.ncbi()

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -5,7 +5,7 @@ import pytest
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
 
-from ref_builder.otu import create_otu, update_otu, add_isolate
+from ref_builder.otu import create_otu, auto_update_otu, add_isolate
 from ref_builder.repo import Repo
 
 
@@ -207,7 +207,7 @@ class TestUpdateOTU:
 
         assert otu.accessions == {"MF062136", "MF062137", "MF062138"}
 
-        update_otu(precached_repo, otu)
+        auto_update_otu(precached_repo, otu)
 
         otu = precached_repo.get_otu(otu.id)
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -200,10 +200,13 @@ class TestUpdateOTU:
     ):
         otu = create_otu(
             precached_repo,
-            345184,
-            ["DQ178610", "DQ178611"],
+            2164102,
+            ["MF062136", "MF062137", "MF062138"],
             "",
         )
+
+        assert otu.accessions == {"MF062136", "MF062137", "MF062138"}
+
         update_otu(precached_repo, otu)
 
         otu = precached_repo.get_otu(otu.id)
@@ -213,13 +216,16 @@ class TestUpdateOTU:
         )
 
         assert otu.accessions == {
-            "DQ178608",
-            "DQ178609",
-            "DQ178610",
-            "DQ178611",
-            "DQ178612",
-            "DQ178613",
-            "DQ178614",
-            "NC_038792",
-            "NC_038793",
+            "MF062136",
+            "MF062137",
+            "MF062138",
+            "MF062130",
+            "MF062131",
+            "MF062132",
+            "OQ420743",
+            "OQ420744",
+            "OQ420745",
+            "MK936225",
+            "MK936226",
+            "MK936227",
         }

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -5,7 +5,8 @@ import pytest
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
 
-from ref_builder.otu import create_otu, update_otu
+import otu
+from ref_builder.otu import create_otu, update_otu, add_isolate
 from ref_builder.repo import Repo
 
 
@@ -184,6 +185,26 @@ class TestCreateOTUCommands:
         assert otu.acronym == "CabLCJV"
 
 
+class TestAddIsolate:
+    def test_ok(self, precached_repo: Repo):
+        isolate_1_accessions = ["DQ178610", "DQ178611"]
+        isolate_2_accessions = ["DQ178613", "DQ178614"]
+
+        otu = create_otu(precached_repo, 345184, isolate_1_accessions, acronym="")
+
+        assert otu.accessions == set(isolate_1_accessions)
+
+        isolate = add_isolate(precached_repo, otu, isolate_2_accessions)
+
+        assert isolate.accessions == set(isolate_2_accessions)
+
+        otu = precached_repo.get_otu_by_taxid(345184)
+
+        assert otu.accessions == set(isolate_1_accessions).union(set(isolate_2_accessions))
+
+
+
+
 class TestAddSequences:
     def test_ok(
         self,
@@ -207,7 +228,6 @@ class TestAddSequences:
                     assert isolate.get_sequence_by_accession(
                         accession,
                     ).dict() == snapshot(exclude=props("id"))
-
 
 @pytest.mark.ncbi()
 class TestUpdateOTU:


### PR DESCRIPTION
- add: `ref-builder otu update [TAXID] isolate [ACCESSIONS]`
- rename: `ref-builder otu update` -> `ref-builder otu update [TAXID] autoupdate`
- remove: `ref-builder sequences create`
- rename: `update_otu()` -> `auto_update_otu()`
- add: `create_isolate()` as new default isolate creation function for both `add_isolate()` and `auto_update_otu()`
- chore: `TestUpdateOTU` now uses `2164102` as test case