### PR TITLE
feat: automatically exclude pre-RefSeq accessions (ECO-77)

### DIFF
--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -5,6 +5,7 @@ from ref_builder.ncbi.models import NCBIGenbank
 from ref_builder.otu.utils import (
     create_schema_from_records,
     group_genbank_records_by_isolate,
+    parse_refseq_comment,
 )
 from ref_builder.repo import Repo
 from ref_builder.resources import RepoOTU
@@ -94,6 +95,13 @@ def create_isolate_from_records(
             segment=record.source.segment,
             sequence=record.sequence,
         )
+
+        if record.refseq:
+            refseq_status, old_accession = parse_refseq_comment(record.comment)
+            repo.exclude_accession(
+                otu.id,
+                old_accession,
+            )
 
     isolate_logger.info(
         f"{isolate.name} created",

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -1,4 +1,6 @@
+import re
 from collections import defaultdict
+from typing import Tuple
 
 import structlog
 
@@ -45,6 +47,19 @@ def group_genbank_records_by_isolate(
             isolates[isolate_name][versioned_accession] = record
 
     return isolates
+
+
+def parse_refseq_comment(comment: str) -> Tuple[str, str]:
+    """Parse a standard RefSeq comment."""
+    if not comment:
+        raise ValueError("Empty comment")
+
+    refseq_pattern = re.compile(r"^(\w+ REFSEQ): [\w ]+. [\w ]+ ([\w]+).")
+
+    match = refseq_pattern.search(comment)
+
+    return match.group(1), match.group(2)
+
 
 
 def _get_molecule_from_records(records: list[NCBIGenbank]) -> Molecule:

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -36,6 +36,7 @@
   dict({
     'acronym': '',
     'excluded_accessions': list([
+      'JX263426',
     ]),
     'legacy_id': None,
     'name': 'Dahlia latent viroid',


### PR DESCRIPTION
`create_otu()` and `create_isolate_from_records()` identify RefSeq records, parse the comment for superceded accessions and automatically add them to the excluded accessions for that OTU.

Partially handles ECO-77. Automatic deletion of existing sequences will be added once deletion events are merged.