### PR TITLE
ECO-77: Add isolate sequence replacement functions

### DIFF
--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -21,7 +21,9 @@ from ref_builder.otu.update import (
     auto_update_otu,
     exclude_accessions_from_otu,
     set_representative_isolate,
+    update_isolate_from_accessions,
 )
+from ref_builder.otu.utils import RefSeqConflictError
 from ref_builder.repo import Repo
 from ref_builder.utils import DataType, IsolateName, IsolateNameType, format_json
 
@@ -218,6 +220,12 @@ def isolate_create(
             accessions_,
             ignore_cache=ignore_cache,
         )
+    except RefSeqConflictError as err:
+        click.echo(
+            f"{err.isolate_name} already exists, but RefSeq items may be promotable,",
+        )
+        sys.exit(1)
+
     except ValueError as e:
         click.echo(e, err=True)
         sys.exit(1)

--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -20,6 +20,7 @@ from ref_builder.otu.update import (
     add_isolate,
     auto_update_otu,
     exclude_accessions_from_otu,
+    promote_otu_accessions,
     set_representative_isolate,
     update_isolate_from_accessions,
 )
@@ -184,6 +185,27 @@ def otu_autoupdate(ctx, debug: bool, ignore_cache: bool) -> None:
     auto_update_otu(repo, otu_, ignore_cache=ignore_cache)
 
 
+@update.command(name="promote")
+@debug_option
+@ignore_cache_option
+@click.pass_context
+def otu_promote_accessions(
+    ctx,
+    debug: bool = False,
+    ignore_cache: bool = False,
+):
+    """Promote all RefSeq accessions within this OTU."""
+    configure_logger(debug)
+
+    taxid = ctx.obj['TAXID']
+
+    repo = ctx.obj['REPO']
+
+    otu_ = repo.get_otu_by_taxid(taxid)
+
+    promote_otu_accessions(repo, otu_, ignore_cache)
+
+
 @update.command(name="isolate")
 @click.argument(
     "accessions_",
@@ -244,6 +266,7 @@ def isolate_create(
 def accession_exclude(
     ctx,
     debug: bool,
+    ignore_cache: bool,
     accessions_: list[str],
 ) -> None:
     """Exclude the given accessions from this OTU."""
@@ -300,6 +323,7 @@ def otu_set_representative_isolate(
         sys.exit(1)
 
     set_representative_isolate(repo, otu_, isolate_id)
+
 
 
 @entry.group()

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -310,6 +310,10 @@ def update_otu_with_accessions(
 
     records = ncbi.fetch_genbank_records(accessions)
 
+    promoted_accessions = promote_otu_accessions(repo, otu, ignore_cache)
+    if promoted_accessions:
+        otu = repo.get_otu(otu.id)
+
     refseq_records, non_refseq_records = _bin_refseq_records(records)
 
     # Add remaining RefSeq records first

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -6,6 +6,7 @@ from ref_builder.ncbi.client import NCBIClient
 from ref_builder.ncbi.models import NCBIGenbank
 from ref_builder.otu.utils import (
     DeleteRationale,
+    RefSeqConflictError,
     create_schema_from_records,
     group_genbank_records_by_isolate,
     parse_refseq_comment,
@@ -76,12 +77,12 @@ def add_isolate(
 
         for record in isolate_records.values():
             if record.accession.startswith("NC_"):
-                otu_logger.debug("Accession is RefSeq")
-                update_isolate_from_records(repo, otu, isolate_id, list(isolate_records.values()))
-
-                otu = repo.get_otu(otu.id)
-
-                return otu.get_isolate(isolate_id)
+                raise RefSeqConflictError(
+                    f"Potential RefSeq replacement for contents of {isolate_name}",
+                    isolate_id=isolate_id,
+                    isolate_name=isolate_name,
+                    accessions=accessions,
+                )
 
             return None
 

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -71,6 +71,20 @@ def add_isolate(
         )
         return None
 
+    if (isolate_id := otu.get_isolate_id_by_name(isolate_name)) is not None:
+        otu_logger.debug(f"{isolate_name} already exists in this OTU")
+
+        for record in isolate_records.values():
+            if record.accession.startswith("NC_"):
+                otu_logger.debug("Accession is RefSeq")
+                update_isolate_from_records(repo, otu, isolate_id, list(isolate_records.values()))
+
+                otu = repo.get_otu(otu.id)
+
+                return otu.get_isolate(isolate_id)
+
+            return None
+
     return create_isolate_from_records(
         repo,
         otu,

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -192,13 +192,13 @@ def update_isolate_from_accessions(
     ignore_cache: bool = False,
 ) -> RepoIsolate | None:
     """Fetch the records attached to a given list of accessions and rebuild the isolate with it."""
-    ncbi = NCBIClient(ignore_cache)
-
-    new_records = ncbi.fetch_genbank_records(accessions)
-
     if (isolate_id := otu.get_isolate_id_by_name(isolate_name)) is None:
         logger.error(f"OTU does not include {isolate_name}.")
         return
+
+    ncbi = NCBIClient(ignore_cache)
+
+    new_records = ncbi.fetch_genbank_records(accessions)
 
     return update_isolate_from_records(repo, otu, isolate_id, new_records)
 
@@ -420,8 +420,8 @@ def add_schema_from_accessions(
         )
 
 
-def remove_isolate_from_otu(repo: Repo, otu: RepoOTU, isolate_id: UUID):
-    """Remove an isolate from the OTU."""
+def delete_isolate_from_otu(repo: Repo, otu: RepoOTU, isolate_id: UUID):
+    """Remove an isolate from a specified OTU."""
     if (isolate := otu.get_isolate(isolate_id)) is None:
         logger.error("This isolate does not exist in this OTU.")
         return

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -477,7 +477,7 @@ def replace_sequence_in_otu(
 
 def promote_otu_accessions(
     repo: Repo, otu_id: UUID, ignore_cache: bool = False
-):
+) -> set | None:
     """Fetch all records from"""
     otu = repo.get_otu(otu_id)
     if otu is None:
@@ -491,6 +491,8 @@ def promote_otu_accessions(
     records = ncbi.fetch_genbank_records(fetch_list)
 
     refseq_records = [record for record in records if record.refseq]
+
+    promoted_accessions = set()
 
     promoted_isolates = defaultdict(list)
 
@@ -520,6 +522,10 @@ def promote_otu_accessions(
             f"{isolate.name} sequences promoted using RefSeq data",
             accessions=promoted_isolate.accessions
         )
+
+        promoted_accessions.update(promoted_isolate.accessions)
+
+    return promoted_accessions
 
 
 def _bin_refseq_records(

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -5,6 +5,7 @@ from structlog import get_logger
 from ref_builder.ncbi.client import NCBIClient
 from ref_builder.ncbi.models import NCBIGenbank
 from ref_builder.otu.utils import (
+    DeleteRationale,
     create_schema_from_records,
     group_genbank_records_by_isolate,
     parse_refseq_comment,
@@ -322,6 +323,18 @@ def add_schema_from_accessions(
             molecule=schema.molecule,
             segments=schema.segments,
         )
+
+
+def remove_isolate_from_otu(repo: Repo, otu: RepoOTU, isolate_id: UUID):
+    """Remove an isolate from the OTU."""
+    if (isolate := otu.get_isolate(isolate_id)) is None:
+        logger.error("This isolate does not exist in this OTU.")
+        return
+
+    repo.delete_isolate(otu.id, isolate.id, rationale=DeleteRationale.USER)
+
+    logger.info(f"{isolate.name} removed.")
+
 
 
 def _bin_refseq_records(

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -11,7 +11,7 @@ from ref_builder.otu.utils import (
     parse_refseq_comment,
 )
 from ref_builder.repo import Repo
-from ref_builder.resources import RepoOTU, RepoIsolate, RepoSequence
+from ref_builder.resources import RepoIsolate, RepoOTU, RepoSequence
 from ref_builder.utils import IsolateName
 
 logger = get_logger("otu.update")

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -1,7 +1,7 @@
 import re
 from collections import defaultdict
 from enum import StrEnum
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import structlog
 
@@ -16,6 +16,20 @@ logger = structlog.get_logger("otu.utils")
 class DeleteRationale(StrEnum):
     USER = "Requested by user"
     REFSEQ = "Superceded by RefSeq"
+
+
+class RefSeqConflictError(ValueError):
+    """Raised when a potential RefSeq replacement is found."""
+    def __init__(
+        self, message, isolate_id: UUID, isolate_name: IsolateName, accessions: list[str]
+    ):
+        super().__init__(message)
+
+        self.isolate_id = isolate_id
+
+        self.isolate_name = isolate_name
+
+        self.accessions = accessions
 
 
 def create_schema_from_records(

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -14,6 +14,7 @@ logger = structlog.get_logger("otu.utils")
 
 
 class DeleteRationale(StrEnum):
+    """Default strings delineating reasons for resource deletion."""
     USER = "Requested by user"
     REFSEQ = "Superceded by RefSeq"
 

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -1,5 +1,6 @@
 import re
 from collections import defaultdict
+from enum import StrEnum
 from uuid import uuid4
 
 import structlog
@@ -10,6 +11,11 @@ from ref_builder.schema import OTUSchema, Segment
 from ref_builder.utils import Accession, IsolateName, IsolateNameType
 
 logger = structlog.get_logger("otu.utils")
+
+
+class DeleteRationale(StrEnum):
+    USER = "Requested by user"
+    REFSEQ = "Superceded by RefSeq"
 
 
 def create_schema_from_records(

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -29,6 +29,16 @@
     'taxid': 345184,
   })
 # ---
+# name: TestCreateOTU.test_otu_create_refseq_autoexclude
+  set({
+    'EF546808',
+    'EF546809',
+    'EF546810',
+    'EF546811',
+    'EF546812',
+    'EF546813',
+  })
+# ---
 # name: TestCreateOTUCommands.test_autofill_ok
   dict({
     'molecule': dict({

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -353,7 +353,7 @@ class TestReplaceIsolateSequences:
 
         updated_isolate = add_isolate(empty_repo, otu_before, refseq_accessions)
 
-        assert updated_isolate is not None
+        assert updated_isolate.accessions == set(refseq_accessions)
 
         otu_after = empty_repo.get_otu(otu_before.id)
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -381,7 +381,7 @@ class TestReplaceSequence:
             precached_repo,
             1169032,
             ["MK431779"],
-            acronym=""
+            acronym="",
         )
 
         isolate_id, old_sequence_id = otu_before.get_sequence_id_hierarchy_from_accession(

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -97,6 +97,35 @@ class TestCreateOTU:
         assert otu.schema is not None
         assert otu.repr_isolate is not None
 
+    def test_otu_create_refseq_autoexclude(
+        self, precached_repo: Repo, snapshot: SnapshotAssertion
+    ):
+        """Test that the superceded accessions included in RefSeq metadata
+        are automatically added to the OTU's excluded accessions list."""
+        otu = create_otu(
+            precached_repo,
+            3158377,
+            [
+                "NC_010314",
+                "NC_010316",
+                "NC_010315",
+                "NC_010317",
+                "NC_010318",
+                "NC_010319",
+            ], ""
+        )
+
+        assert (
+            otu.excluded_accessions == {
+                "EF546808",
+                "EF546809",
+                "EF546810",
+                "EF546811",
+                "EF546812",
+                "EF546813",
+            } == snapshot
+        )
+
     def test_otu_create_with_acronym_auto(self, precached_repo: Repo):
         otu = create_otu(
             precached_repo,

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -343,9 +343,11 @@ class TestReplaceIsolateSequences:
         """Test that an attempt to add an isolate with the same name as a previous isolate
         maintains the same isolate UUID, but replaces the existing sequences including
         sequence UUIDs."""
-        otu_before = create_otu(empty_repo, taxid, accessions=original_accessions, acronym="")
+        create_otu(
+            empty_repo, taxid, accessions=original_accessions, acronym=""
+        )
 
-        otu_before = empty_repo.get_otu(otu_before.id)
+        otu_before = empty_repo.get_otu_by_taxid(taxid)
 
         assert otu_before.accessions == set(original_accessions)
 
@@ -354,6 +356,8 @@ class TestReplaceIsolateSequences:
         assert updated_isolate is not None
 
         otu_after = empty_repo.get_otu(otu_before.id)
+
+        assert otu_after.get_isolate(updated_isolate.id) == updated_isolate
 
         assert otu_after.isolate_ids == otu_before.isolate_ids
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -349,58 +349,6 @@ class TestReplaceIsolateSequences:
         with pytest.raises(RefSeqConflictError):
             add_isolate(empty_repo, otu_before, refseq_accessions)
 
-    def test_isolate_promote_ok(
-        self,
-        empty_repo,
-        taxid: int,
-        original_accessions: list[str],
-        refseq_accessions: list[str],
-    ):
-        """Test that an attempt to add an isolate with the same name as a previous isolate
-        maintains the same isolate UUID, but replaces the existing sequences including
-        sequence UUIDs."""
-        create_otu(
-            empty_repo, taxid, accessions=original_accessions, acronym=""
-        )
-
-        otu_before = empty_repo.get_otu_by_taxid(taxid)
-
-        assert otu_before.accessions == set(original_accessions)
-
-        isolate_id = list(otu_before.isolate_ids)[0]
-
-        # subprocess.run(
-        #     ["ref-builder", "otu", "update"]
-        #     + [str(taxid)]
-        #     + ["isolate"]
-        #     + refseq_accessions,
-        #     check=False,
-        # )
-        #
-        # print(empty_repo.path)
-        #
-        # try:
-        #     updated_repo = Repo(empty_repo.path)
-        # except FileNotFoundError:
-        #     print("????")
-        #     return
-        #
-        # updated_isolate = updated_repo.get_otu_by_taxid(taxid).get_isolate(isolate_id)
-        #
-        # assert updated_isolate.accessions == set(refseq_accessions)
-        #
-        # otu_after = updated_repo.get_otu(otu_before.id)
-        #
-        # assert otu_after.get_isolate(updated_isolate.id) == updated_isolate
-        #
-        # assert otu_after.isolate_ids == otu_before.isolate_ids
-        #
-        # assert otu_after.accessions == set(refseq_accessions)
-        #
-        # assert otu_after.excluded_accessions == set(original_accessions)
-        #
-        # assert otu_after.sequence_ids != otu_before.sequence_ids
-
 
 class TestRemoveIsolate:
     def test_ok(self, scratch_repo):

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -296,6 +296,70 @@ class TestUpdateOTU:
             "NC_055392",
         }
 
+    def test_with_replacement_ok(
+        self,
+        precached_repo: Repo,
+        snapshot: SnapshotAssertion,
+    ):
+        otu_before = create_otu(
+            precached_repo,
+            2164102,
+            ["MF062125", "MF062126", "MF062127"],
+            "",
+        )
+
+        assert (
+            otu_before.accessions
+            ==
+            otu_before.get_isolate(otu_before.repr_isolate).accessions
+            ==
+            {"MF062125", "MF062126", "MF062127"}
+        )
+
+        auto_update_otu(precached_repo, otu_before)
+
+        otu_after = precached_repo.get_otu(otu_before.id)
+
+        assert otu_after.get_isolate(otu_after.repr_isolate).accessions == {
+            "NC_055390",
+            "NC_055391",
+            "NC_055392",
+        }
+
+        assert {"MF062125", "MF062126", "MF062127"}.isdisjoint(otu_after.accessions)
+
+        assert otu_after.repr_isolate == otu_before.repr_isolate
+
+        assert (
+            otu_after.get_isolate(otu_before.repr_isolate).accessions
+            !=
+            otu_before.get_isolate(otu_before.repr_isolate).accessions
+        )
+
+        assert otu_after.id == otu_before.id
+
+        assert otu_after.isolate_ids.issuperset(otu_before.isolate_ids)
+
+        assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}
+
+        assert otu_after.accessions == {
+            "MF062136",
+            "MF062137",
+            "MF062138",
+            "MF062130",
+            "MF062131",
+            "MF062132",
+            "MK936225",
+            "MK936226",
+            "MK936227",
+            "OQ420743",
+            "OQ420744",
+            "OQ420745",
+            "NC_055390",
+            "NC_055391",
+            "NC_055392",
+        }
+
 
 @pytest.mark.parametrize(
         "taxid, original_accessions, refseq_accessions",

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -358,7 +358,6 @@ class TestReplaceIsolateSequences:
         assert otu_after.sequence_ids != otu_before.sequence_ids
 
 
-
 class TestRemoveIsolate:
     @pytest.mark.parametrize(
         "taxid, isolate_name",

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -10,7 +10,7 @@ from ref_builder.otu.create import create_otu
 from ref_builder.otu.update import (
     auto_update_otu,
     add_isolate,
-    remove_isolate_from_otu,
+    delete_isolate_from_otu,
     replace_sequence_in_otu,
     update_isolate_from_accessions,
 )
@@ -381,7 +381,7 @@ class TestRemoveIsolate:
 
         assert type(isolate_id) is UUID
 
-        remove_isolate_from_otu(scratch_repo, otu_before, isolate_id)
+        delete_isolate_from_otu(scratch_repo, otu_before, isolate_id)
 
         otu_after = scratch_repo.get_otu_by_taxid(taxid)
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -11,6 +11,7 @@ from ref_builder.otu.update import (
     auto_update_otu,
     add_isolate,
     remove_isolate_from_otu,
+    replace_sequence_in_otu,
     update_isolate_from_accessions,
 )
 from ref_builder.repo import Repo
@@ -311,3 +312,34 @@ class TestReplaceIsolateSequences:
         assert otu_after.get_isolate(isolate_after.id).accessions == set(refseq_accessions)
 
         assert otu_after.excluded_accessions == set(original_accessions)
+
+
+class TestReplaceSequence:
+    def test_ok(self, precached_repo):
+        otu_before = create_otu(
+            precached_repo,
+            1169032,
+            ["MK431779"],
+            acronym=""
+        )
+        """Test that a sequence in an OTU can be replaced manually."""
+        isolate_id, old_sequence_id = otu_before.get_sequence_id_hierarchy_from_accession(
+            "MK431779"
+        )
+
+        assert type(old_sequence_id) is UUID
+
+        sequence = replace_sequence_in_otu(
+            repo=precached_repo,
+            otu=otu_before,
+            new_accession="NC_003355",
+            replaced_accession="MK431779"
+        )
+
+        assert sequence is not None
+
+        otu_after = precached_repo.get_otu_by_taxid(1169032)
+
+        assert otu_after.accessions == {"NC_003355"}
+
+        assert otu_after.get_isolate(isolate_id).accessions == {"NC_003355"}

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -232,6 +232,21 @@ class TestAddIsolate:
 
         assert otu.get_isolate(isolate.id).accessions == set(isolate_2_accessions)
 
+    def test_conflict_fail(self, precached_repo: Repo):
+        """Test that an isolate cannot be added to an OTU
+        if both its name and its accessions are already contained."""
+        taxid = 2164102
+        accessions = ["MF062136", "MF062137", "MF062138"]
+
+        otu = create_otu(
+            precached_repo,
+            taxid,
+            accessions,
+            "",
+        )
+
+        assert add_isolate(precached_repo, otu, accessions) is None
+
 
 @pytest.mark.ncbi()
 class TestUpdateOTU:

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -119,7 +119,7 @@ class TestPromoteAccessions:
 
         assert otu_before.get_isolate(isolate.id).accessions == {"MF062125", "MF062126", "MF062127"}
 
-        promoted_accessions = promote_otu_accessions(empty_repo, otu)
+        promoted_accessions = promote_otu_accessions(empty_repo, otu_before)
 
         assert promoted_accessions == {"NC_055390", "NC_055391", "NC_055392"}
 

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -135,3 +135,35 @@ class TestPromoteAccessions:
         assert otu_after.get_isolate(isolate.id).accessions == {"NC_055390", "NC_055391", "NC_055392"}
 
         assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}
+
+    def test_command_ok(self, empty_repo: Repo):
+        otu = create_otu(
+            empty_repo,
+            2164102,
+            ["MF062125", "MF062126", "MF062127"],
+            acronym=""
+        )
+
+        otu_before = empty_repo.get_otu(otu.id)
+
+        assert otu_before.accessions == {"MF062125", "MF062126", "MF062127"}
+
+        subprocess.run(
+            [
+                "ref-builder",
+                "otu",
+                "update",
+            ]
+            + ["--path", str(empty_repo.path)]
+            + [str(2164102)]
+            + ["promote"],
+            check=False,
+        )
+
+        repo_after = Repo(empty_repo.path)
+
+        otu_after = repo_after.get_otu(otu.id)
+
+        assert otu_after.repr_isolate == otu_before.repr_isolate
+
+        assert otu_after.accessions == {"NC_055390", "NC_055391", "NC_055392",}

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -1,7 +1,12 @@
 import subprocess
 
 from ref_builder.repo import Repo
-from ref_builder.otu.update import set_representative_isolate
+from ref_builder.otu.create import create_otu
+from ref_builder.otu.update import (
+    add_isolate,
+    promote_otu_accessions,
+    set_representative_isolate,
+)
 
 
 def test_update_representative_isolate(scratch_repo: Repo):
@@ -92,3 +97,41 @@ class TestUpdateRepresentativeIsolateCommand:
         assert otu_after.repr_isolate != otu_before.repr_isolate
 
         assert otu_after.repr_isolate == otu_before.get_isolate_id_by_name(repr_isolate_name_after)
+
+
+class TestPromoteAccessions:
+    def test_ok(self, empty_repo: Repo):
+        """Test that RefSeq accessions can be promoted automatically."""
+        otu = create_otu(
+            empty_repo,
+            2164102,
+            ["MF062136", "MF062137", "MF062138"],
+            acronym=""
+        )
+        isolate = add_isolate(empty_repo, otu, ["MF062125", "MF062126", "MF062127"])
+
+        otu_before = empty_repo.get_otu(otu.id)
+
+        assert otu_before.accessions == {
+            "MF062125", "MF062126", "MF062127",
+            "MF062136", "MF062137", "MF062138"
+        }
+
+        assert otu_before.get_isolate(isolate.id).accessions == {"MF062125", "MF062126", "MF062127"}
+
+        promoted_accessions = promote_otu_accessions(empty_repo, otu)
+
+        assert promoted_accessions == {"NC_055390", "NC_055391", "NC_055392"}
+
+        otu_after = empty_repo.get_otu(otu.id)
+
+        assert otu_after.isolate_ids == otu_before.isolate_ids
+
+        assert otu_after.accessions == {
+            "NC_055390", "NC_055391", "NC_055392",
+            "MF062136", "MF062137", "MF062138",
+        }
+
+        assert otu_after.get_isolate(isolate.id).accessions == {"NC_055390", "NC_055391", "NC_055392"}
+
+        assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}


### PR DESCRIPTION
* add `otu.update.delete_isolate_from_otu()`, `.update_isolate_from_records()`, `.update_isolate_from_accessions()`
* add `otu.utils.DeleteRationale` enum
* add `otu.utils.RefSeqConflictError` to handle `add_isolate()` cases where an automatic RefSeq promotion is likely possible