### PR TITLE
ECO-64: Handle segment name ambiguity

### DIFF
--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -6,7 +6,7 @@ import structlog
 
 from ref_builder.models import Molecule
 from ref_builder.ncbi.models import NCBIGenbank
-from ref_builder.schema import Segment, OTUSchema
+from ref_builder.schema import Segment, OTUSchema, parse_segment_name
 from ref_builder.utils import IsolateName, Accession, IsolateNameType
 
 
@@ -123,7 +123,7 @@ def _get_segments_from_records(records: list[NCBIGenbank]) -> list[Segment]:
         record = records[0]
 
         if record.source.segment != "":
-            segment_name = record.source.segment
+            segment_name = parse_segment_name(record.source.segment)
         else:
             segment_name = record.source.organism
 
@@ -134,7 +134,7 @@ def _get_segments_from_records(records: list[NCBIGenbank]) -> list[Segment]:
         if record.source.segment:
             segments.append(
                 Segment(
-                    name=record.source.segment,
+                    name=parse_segment_name(record.source.segment),
                     required=True,
                     length=len(record.sequence),
                 ),

--- a/ref_builder/schema.py
+++ b/ref_builder/schema.py
@@ -1,3 +1,5 @@
+import re
+
 from pydantic import BaseModel, computed_field
 
 from ref_builder.models import Molecule
@@ -27,3 +29,23 @@ class OTUSchema(BaseModel):
     @computed_field
     def multipartite(self) -> bool:
         return len(self.segments) > 1
+
+
+simple_name_pattern = re.compile(r"([A-Za-z0-9])+")
+
+complex_name_pattern = re.compile(r"([A-Za-z]+)[-_ ]+([A-Za-z0-9]+)")
+
+
+def parse_segment_name(raw: str):
+    """Takes a raw segment name from a NCBI Genbank source table
+    and standardizes the relevant identifier"""
+    if simple_name_pattern.fullmatch(raw):
+        return raw
+
+    segment_name_parse = complex_name_pattern.fullmatch(raw)
+    if segment_name_parse:
+        return segment_name_parse.group(2)
+
+    raise ValueError(f"{raw} is not a valid segment name")
+
+

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -16,12 +16,12 @@
       'segments': list([
         dict({
           'length': 2575,
-          'name': 'DNA-A',
+          'name': 'A',
           'required': True,
         }),
         dict({
           'length': 2494,
-          'name': 'DNA-B',
+          'name': 'B',
           'required': True,
         }),
       ]),
@@ -30,7 +30,7 @@
   })
 # ---
 # name: TestCreateOTUCommands.test_autofill_ok
-  OTUSchema(molecule=Molecule(strandedness='double', topology='circular', type='DNA'), segments=[Segment(name='DNA-A', required=True, length=2575), Segment(name='DNA-B', required=True, length=2494)], multipartite=True)
+  OTUSchema(molecule=Molecule(strandedness='double', topology='circular', type='DNA'), segments=[Segment(name='A', required=True, length=2575), Segment(name='B', required=True, length=2494)], multipartite=True)
 # ---
 # name: TestCreateOTUCommands.test_ok[1278205-accessions0]
   dict({
@@ -75,12 +75,12 @@
       'segments': list([
         dict({
           'length': 2575,
-          'name': 'DNA-A',
+          'name': 'A',
           'required': True,
         }),
         dict({
           'length': 2494,
-          'name': 'DNA-B',
+          'name': 'B',
           'required': True,
         }),
       ]),

--- a/tests/ref/__snapshots__/test_schema.ambr
+++ b/tests/ref/__snapshots__/test_schema.ambr
@@ -27,32 +27,32 @@
     'segments': list([
       dict({
         'length': 1090,
-        'name': 'DNA N',
+        'name': 'N',
         'required': True,
       }),
       dict({
         'length': 1057,
-        'name': 'DNA U3',
+        'name': 'U3',
         'required': True,
       }),
       dict({
         'length': 1087,
-        'name': 'DNA S',
+        'name': 'S',
         'required': True,
       }),
       dict({
         'length': 1074,
-        'name': 'DNA M',
+        'name': 'M',
         'required': True,
       }),
       dict({
         'length': 1015,
-        'name': 'DNA C',
+        'name': 'C',
         'required': True,
       }),
       dict({
         'length': 1099,
-        'name': 'DNA R',
+        'name': 'R',
         'required': True,
       }),
     ]),

--- a/tests/ref/test_schema.py
+++ b/tests/ref/test_schema.py
@@ -2,7 +2,7 @@ import pytest
 from syrupy import SnapshotAssertion
 
 from ref_builder.otu.update import create_schema_from_records
-from ref_builder.schema import OTUSchema
+from ref_builder.schema import OTUSchema, parse_segment_name
 
 
 @pytest.mark.parametrize(
@@ -30,3 +30,37 @@ def test_create_schema_from_records(
     assert type(auto_schema) is OTUSchema
 
     assert auto_schema.model_dump() == snapshot
+
+
+class TestSegmentNameParser:
+    @pytest.mark.parametrize(
+        "expected_result, test_strings",
+        [
+            ("A", ["A", "DNA A", "DNA_A", "DNA-A"]),
+            ("BN", ["BN", "RNA BN", "RNA_BN", "RNA-BN"]),
+            ("U3", ["U3", "DNA U3", "DNA U3", "DNA-U3"]),
+        ],
+    )
+    def test_ok(self, expected_result: str, test_strings: list[str]):
+        assert (
+            parse_segment_name(test_strings[0])
+            ==
+            parse_segment_name(test_strings[1])
+            ==
+            parse_segment_name(test_strings[2])
+            ==
+            parse_segment_name(test_strings[3])
+            ==
+            expected_result
+        )
+
+    @pytest.mark.parametrize(
+        "fail_case",
+        ["", "*V/", "51f9a0bc-7b3b-434f-bf4c-f7abaa015b8d"]
+    )
+    def test_fail(self, fail_case: str):
+        with pytest.raises(ValueError):
+            parse_segment_name(fail_case)
+
+
+


### PR DESCRIPTION
Standardize segment names to identifier only. `A`, `DNA A`, `DNA-A` and `DNA_A` all standardize to `A`.