### PR TITLE
Refactor `Repo.create_isolate`

### DIFF
--- a/ref_builder/otu/create.py
+++ b/ref_builder/otu/create.py
@@ -11,7 +11,6 @@ from ref_builder.otu.utils import (
 from ref_builder.repo import Repo
 from ref_builder.resources import RepoOTU
 
-
 logger = structlog.get_logger("otu.create")
 
 
@@ -88,8 +87,7 @@ def create_otu(
     isolate = repo.create_isolate(
         otu_id=otu.id,
         legacy_id=None,
-        source_name=isolate_name.value,
-        source_type=isolate_name.type,
+        name=isolate_name,
     )
 
     otu.add_isolate(isolate)

--- a/ref_builder/otu/create.py
+++ b/ref_builder/otu/create.py
@@ -42,6 +42,7 @@ def create_otu(
         )
 
     taxonomy = client.fetch_taxonomy_record(taxid)
+
     if taxonomy is None:
         otu_logger.fatal(f"Could not retrieve {taxid} from NCBI Taxonomy")
         return None
@@ -51,6 +52,7 @@ def create_otu(
             acronym = taxonomy.other_names.acronym[0]
 
     records = client.fetch_genbank_records(accessions)
+
     if len(records) != len(accessions):
         otu_logger.fatal("Could not retrieve all requested accessions.")
         return None

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -93,15 +93,18 @@ def create_isolate_from_records(
         taxid=otu.taxid,
     )
 
-    if otu.get_isolate_id_by_name(isolate_name) is not None:
-        isolate_logger.error(f"OTU already contains {isolate_name}.")
-        return None
+    try:
+        isolate = repo.create_isolate(
+            otu.id,
+            None,
+            isolate_name,
+        )
+    except ValueError as e:
+        if "Isolate name already exists" in str(e):
+            isolate_logger.error("OTU already contains isolate with name.")
+            return None
 
-    isolate = repo.create_isolate(
-        otu.id,
-        None,
-        isolate_name,
-    )
+        raise
 
     for record in records:
         repo.create_sequence(
@@ -131,7 +134,9 @@ def create_isolate_from_records(
 
 
 def set_representative_isolate(
-    repo: Repo, otu: RepoOTU, isolate_id: UUID
+    repo: Repo,
+    otu: RepoOTU,
+    isolate_id: UUID,
 ) -> UUID | None:
     """Sets an OTU's representative isolate to a given existing isolate ID.
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -188,7 +188,7 @@ class Repo:
         if (otu_id := self.get_otu_by_taxid(taxid)) is not None:
             otu = self.get_otu(otu_id)
             raise ValueError(
-                f"OTU  already exists as {otu}",
+                f"OTU already exists as {otu}",
             )
 
         if self._snapshotter.get_id_by_name(name):

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -64,7 +64,6 @@ from ref_builder.utils import (
     Accession,
     DataType,
     IsolateName,
-    IsolateNameType,
     pad_zeroes,
 )
 
@@ -189,7 +188,7 @@ class Repo:
         if (otu_id := self.get_otu_by_taxid(taxid)) is not None:
             otu = self.get_otu(otu_id)
             raise ValueError(
-                f"OTU already exists as {otu}",
+                f"OTU  already exists as {otu}",
             )
 
         if self._snapshotter.get_id_by_name(name):
@@ -224,15 +223,13 @@ class Repo:
         self,
         otu_id: uuid.UUID,
         legacy_id: str | None,
-        source_name: str,
-        source_type: IsolateNameType,
+        name: IsolateName,
     ) -> RepoIsolate | None:
-        """Create and return a new isolate within the given OTU.
+        """Create and isolate for the OTU with ``otu_id``.
+
         If the isolate name already exists, return None.
         """
         otu = self.get_otu(otu_id)
-
-        name = IsolateName(type=source_type, value=source_name)
 
         if otu.get_isolate_id_by_name(name) is not None:
             logger.warning(
@@ -256,9 +253,7 @@ class Repo:
             name=str(name),
         )
 
-        otu = self.get_otu(otu_id)
-
-        return otu.get_isolate(isolate_id)
+        return self.get_otu(otu_id).get_isolate(isolate_id)
 
     def delete_isolate(
         self,

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -231,12 +231,8 @@ class Repo:
         """
         otu = self.get_otu(otu_id)
 
-        if otu.get_isolate_id_by_name(name) is not None:
-            logger.warning(
-                "An isolate by this name already exists",
-                isolate_name=str(name),
-            )
-            return None
+        if otu.get_isolate_id_by_name(name):
+            raise ValueError(f"Isolate name already exists: {name}")
 
         isolate_id = uuid.uuid4()
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -33,7 +33,11 @@ def initialized_repo(empty_repo: Repo):
         12242,
     )
 
-    isolate_a = empty_repo.create_isolate(otu.id, None, "A", IsolateNameType.ISOLATE)
+    isolate_a = empty_repo.create_isolate(
+        otu.id,
+        None,
+        IsolateName(IsolateNameType.ISOLATE, "A"),
+    )
     empty_repo.create_sequence(
         otu.id,
         isolate_a.id,
@@ -231,7 +235,11 @@ def test_create_isolate(empty_repo: Repo):
     """
     otu = init_otu(empty_repo)
 
-    isolate = empty_repo.create_isolate(otu.id, None, "A", IsolateNameType.ISOLATE)
+    isolate = empty_repo.create_isolate(
+        otu.id,
+        None,
+        IsolateName(IsolateNameType.ISOLATE, "A"),
+    )
 
     assert isinstance(isolate.id, UUID)
     assert isolate.sequences == []
@@ -266,7 +274,11 @@ def test_create_sequence(empty_repo: Repo):
     """
     otu = init_otu(empty_repo)
 
-    isolate = empty_repo.create_isolate(otu.id, None, "A", IsolateNameType.ISOLATE)
+    isolate = empty_repo.create_isolate(
+        otu.id,
+        None,
+        IsolateName(IsolateNameType.ISOLATE, "A"),
+    )
 
     sequence = empty_repo.create_sequence(
         otu.id,
@@ -338,9 +350,9 @@ class TestRetrieveOTU:
         isolate_a = empty_repo.create_isolate(
             otu.id,
             None,
-            "A",
-            IsolateNameType.ISOLATE,
+            IsolateName(IsolateNameType.ISOLATE, "A"),
         )
+
         empty_repo.create_sequence(
             otu.id,
             isolate_a.id,
@@ -354,8 +366,7 @@ class TestRetrieveOTU:
         isolate_b = empty_repo.create_isolate(
             otu.id,
             None,
-            "B",
-            IsolateNameType.ISOLATE,
+            IsolateName(IsolateNameType.ISOLATE, "B"),
         )
         empty_repo.create_sequence(
             otu.id,
@@ -437,8 +448,7 @@ class TestRetrieveOTU:
         isolate_b = initialized_repo.create_isolate(
             otu.id,
             None,
-            "B",
-            IsolateNameType.ISOLATE,
+            IsolateName(type=IsolateNameType.ISOLATE, value="B"),
         )
         initialized_repo.create_sequence(
             otu.id,
@@ -460,8 +470,7 @@ class TestRetrieveOTU:
         isolate_b = initialized_repo.create_isolate(
             otu.id,
             None,
-            "B",
-            IsolateNameType.ISOLATE,
+            IsolateName(type=IsolateNameType.ISOLATE, value="B"),
         )
 
         initialized_repo.create_sequence(
@@ -552,7 +561,9 @@ class TestDirectDelete:
         isolate_before = list(otu_before.isolates)[0]
 
         initialized_repo.delete_isolate(
-            otu_id, isolate_before.id, rationale="Testing redaction"
+            otu_id,
+            isolate_before.id,
+            rationale="Testing redaction",
         )
 
         otu_after = initialized_repo.get_otu(otu_id)
@@ -573,7 +584,9 @@ class TestDirectDelete:
 
         accession = "TMVABC"
 
-        isolate_id, replaced_sequence_id = otu_before.get_sequence_id_hierarchy_from_accession(accession)
+        isolate_id, replaced_sequence_id = (
+            otu_before.get_sequence_id_hierarchy_from_accession(accession)
+        )
 
         assert otu_before.get_isolate(isolate_id).accessions == {"TMVABC"}
 
@@ -600,4 +613,3 @@ class TestDirectDelete:
         assert new_sequence.id in otu_after.sequence_ids
 
         assert otu_after.get_isolate(isolate_id).accessions == {"TMVABCC"}
-


### PR DESCRIPTION
* Take `IsolateName` instead of source_type and source_name.
* Raise a `ValueError` instead of returning `None` when the isolate name already exists. This makes the method consistent with `create_otu`.
* Add a test for the name clash error.

