### PR TITLE
chore: ignore EM102 about f-strings in exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["ANN101", "D205", "EM101", "FBT001", "FBT003", "PTH123", "TRY003"]
+ignore = ["ANN101", "D205", "EM101", "EM102", "FBT001", "FBT003", "PTH123", "TRY003"]
 
 [tool.ruff.per-file-ignores]
 "tests/**" = ["ANN201", "ANN202", "D205", "PLR2004", "S101", "S106"]


### PR DESCRIPTION
This is annoying and resolving it makes the code unnecessarily verbose.