### PR TITLE
ECO-64: Handle segment name ambiguity

### DIFF
--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -252,7 +252,7 @@ class NCBIClient:
         :param raw: A NCBI Nucleotide dict record, parsed by Bio.Entrez.Parser
         :return: A validated subset of Genbank record data
         """
-        return NCBIGenbank(**raw)
+        return NCBIGenbank.model_validate(raw)
 
     def fetch_taxonomy_record(self, taxid: int) -> NCBITaxonomy | None:
         """Fetch and validate a taxonomy record from NCBI Taxonomy.

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -7,7 +7,7 @@ import structlog
 
 from ref_builder.models import Molecule
 from ref_builder.ncbi.models import NCBIGenbank
-from ref_builder.schema import OTUSchema, Segment
+from ref_builder.schema import OTUSchema, SegmentName, Segment, parse_segment_name
 from ref_builder.utils import Accession, IsolateName, IsolateNameType
 
 logger = structlog.get_logger("otu.utils")
@@ -118,6 +118,8 @@ def _get_molecule_from_records(records: list[NCBIGenbank]) -> Molecule:
     )
 
 
+simple_name_pattern = re.compile(r"([A-Za-z0-9])+")
+
 def _get_isolate_name(record: NCBIGenbank) -> IsolateName | None:
     """Get the isolate name from a Genbank record"""
     if record.source.model_fields_set.intersection(
@@ -155,11 +157,18 @@ def _get_segments_from_records(records: list[NCBIGenbank]) -> list[Segment]:
     segments = []
     for record in sorted(records, key=lambda record: record.accession):
         if record.source.segment:
+            if simple_name_pattern.fullmatch(record.source.segment):
+                segment_name = SegmentName(
+                    prefix=record.moltype, key=record.source.segment
+                )
+            else:
+                segment_name = parse_segment_name(record.source.segment)
+
             segment_id = uuid4()
             segments.append(
                 Segment(
                     id=segment_id,
-                    name=record.source.segment,
+                    name=str(segment_name),
                     required=True,
                     length=len(record.sequence),
                 ),

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -7,8 +7,15 @@ import structlog
 
 from ref_builder.models import Molecule, MolType
 from ref_builder.ncbi.models import NCBIGenbank
-from ref_builder.schema import OTUSchema, SegmentName, Segment, parse_segment_name
+from ref_builder.schema import OTUSchema, SegmentName, Segment
 from ref_builder.utils import Accession, IsolateName, IsolateNameType
+
+
+SIMPLE_NAME_PATTERN = re.compile(r"([A-Za-z0-9])+")
+"""Regex pattern for parsing segment name strings with no prefix."""
+
+COMPLEX_NAME_PATTERN = re.compile(r"([A-Za-z]+)[-_ ]+([A-Za-z0-9]+)")
+"""Regex pattern for parsing segment name strings consisting of a prefix and a key."""
 
 logger = structlog.get_logger("otu.utils")
 
@@ -170,13 +177,21 @@ def _get_segments_from_records(records: list[NCBIGenbank]) -> list[Segment]:
     return segments
 
 
-simple_name_pattern = re.compile(r"([A-Za-z0-9])+")
-
-
 def get_multipartite_segment_name(record: NCBIGenbank) -> SegmentName:
-    if simple_name_pattern.fullmatch(record.source.segment):
+    if SIMPLE_NAME_PATTERN.fullmatch(record.source.segment):
         return SegmentName(
             prefix=record.moltype, key=record.source.segment
         )
     else:
         return parse_segment_name(record.source.segment)
+
+
+def parse_segment_name(raw: str) -> SegmentName:
+    segment_name_parse = COMPLEX_NAME_PATTERN.fullmatch(raw)
+    if segment_name_parse:
+        return SegmentName(
+            prefix=segment_name_parse.group(1),
+            key=segment_name_parse.group(2)
+        )
+
+    raise ValueError(f"{raw} is not a valid segment name")

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -178,15 +178,17 @@ def _get_segments_from_records(records: list[NCBIGenbank]) -> list[Segment]:
 
 
 def get_multipartite_segment_name(record: NCBIGenbank) -> SegmentName:
+    """Get a multipartite segment name from the record."""
     if SIMPLE_NAME_PATTERN.fullmatch(record.source.segment):
         return SegmentName(
-            prefix=record.moltype, key=record.source.segment
+            prefix=record.moltype, key=record.source.segment,
         )
-    else:
-        return parse_segment_name(record.source.segment)
+
+    return parse_segment_name(record.source.segment)
 
 
 def parse_segment_name(raw: str) -> SegmentName:
+    """Parse a SegmentName from a raw string."""
     segment_name_parse = COMPLEX_NAME_PATTERN.fullmatch(raw)
     if segment_name_parse:
         return SegmentName(

--- a/ref_builder/schema.py
+++ b/ref_builder/schema.py
@@ -1,9 +1,15 @@
 import re
+from typing import NamedTuple
 
 from pydantic import BaseModel, UUID4, computed_field
 
 from ref_builder.models import Molecule
 from ref_builder.ncbi.models import NCBISourceMolType
+
+
+class SegmentName(NamedTuple):
+    prefix: str
+    key: str
 
 
 class Segment(BaseModel):

--- a/ref_builder/schema.py
+++ b/ref_builder/schema.py
@@ -1,16 +1,19 @@
-from typing import NamedTuple
-
 from pydantic import UUID4, BaseModel, computed_field
+from pydantic.dataclasses import dataclass
 
 from ref_builder.models import Molecule
 from ref_builder.ncbi.models import NCBISourceMolType
 
 
-class SegmentName(NamedTuple):
+@dataclass(frozen=True)
+class SegmentName:
     """A normalized segment name. Can be used as a key."""
 
     prefix: str
+    """The prefix of the segment name."""
+
     key: str
+    """The identifying key portion of the segment name."""
 
     def __str__(self) -> str:
         """Return the segment name as a formatted string."""

--- a/ref_builder/schema.py
+++ b/ref_builder/schema.py
@@ -40,11 +40,6 @@ class OTUSchema(BaseModel):
         return len(self.segments) > 1
 
 
-simple_name_pattern = re.compile(r"([A-Za-z0-9])+")
-
-complex_name_pattern = re.compile(r"([A-Za-z]+)[-_ ]+([A-Za-z0-9]+)")
-
-
 def set_segment_prefix(moltype: NCBISourceMolType):
     if moltype in (
         NCBISourceMolType.GENOMIC_DNA,
@@ -68,12 +63,17 @@ def set_segment_prefix(moltype: NCBISourceMolType):
             return "RNA"
 
 
-def parse_segment_name(raw: str):
-    if simple_name_pattern.fullmatch(raw):
-        return raw
+simple_name_pattern = re.compile(r"([A-Za-z0-9])+")
 
+complex_name_pattern = re.compile(r"([A-Za-z]+)[-_ ]+([A-Za-z0-9]+)")
+
+
+def parse_segment_name(raw: str) -> SegmentName:
     segment_name_parse = complex_name_pattern.fullmatch(raw)
     if segment_name_parse:
-        return segment_name_parse.group(1), segment_name_parse.group(2)
+        return SegmentName(
+            prefix=segment_name_parse.group(1),
+            key=segment_name_parse.group(2)
+        )
 
     raise ValueError(f"{raw} is not a valid segment name")

--- a/ref_builder/schema.py
+++ b/ref_builder/schema.py
@@ -46,6 +46,7 @@ class OTUSchema(BaseModel):
 
     @computed_field
     def multipartite(self) -> bool:
+        """Is true if multiple sequences are required to form a complete isolate."""
         return len(self.segments) > 1
 
 
@@ -60,7 +61,7 @@ def determine_segment_prefix(moltype: NCBISourceMolType) -> str:
     ):
         return "DNA"
 
-    prefix = ""
+    prefix = None
 
     match moltype:
         case NCBISourceMolType.GENOMIC_RNA:

--- a/ref_builder/schema.py
+++ b/ref_builder/schema.py
@@ -1,3 +1,5 @@
+import re
+
 from pydantic import BaseModel, UUID4, computed_field
 
 from ref_builder.models import Molecule
@@ -29,3 +31,23 @@ class OTUSchema(BaseModel):
     @computed_field
     def multipartite(self) -> bool:
         return len(self.segments) > 1
+
+
+simple_name_pattern = re.compile(r"([A-Za-z0-9])+")
+
+complex_name_pattern = re.compile(r"([A-Za-z]+)[-_ ]+([A-Za-z0-9]+)")
+
+
+def parse_segment_name(raw: str):
+    """Takes a raw segment name from a NCBI Genbank source table
+    and standardizes the relevant identifier"""
+    if simple_name_pattern.fullmatch(raw):
+        return raw
+
+    segment_name_parse = complex_name_pattern.fullmatch(raw)
+    if segment_name_parse:
+        return segment_name_parse.group(2)
+
+    raise ValueError(f"{raw} is not a valid segment name")
+
+

--- a/ref_builder/schema.py
+++ b/ref_builder/schema.py
@@ -1,14 +1,14 @@
 from typing import NamedTuple
 
-from pydantic import BaseModel, UUID4, computed_field
+from pydantic import UUID4, BaseModel, computed_field
 
 from ref_builder.models import Molecule
 from ref_builder.ncbi.models import NCBISourceMolType
 
-"""Regex pattern for parsing segment name strings containing both a prefix and a key."""
-
 
 class SegmentName(NamedTuple):
+    """A normalized segment name. Can be used as a key."""
+
     prefix: str
     key: str
 
@@ -18,7 +18,8 @@ class SegmentName(NamedTuple):
 
 
 class Segment(BaseModel):
-    """The metadata of the segment"""
+    """The metadata of the segment."""
+
     id: UUID4
     """The unique id number of this segment"""
 
@@ -32,7 +33,7 @@ class Segment(BaseModel):
 
 
 class OTUSchema(BaseModel):
-    """A schema for the intended data"""
+    """A schema for the intended data."""
 
     molecule: Molecule
     """The molecular metadata for this OTU."""
@@ -46,8 +47,8 @@ class OTUSchema(BaseModel):
 
 
 def determine_segment_prefix(moltype: NCBISourceMolType) -> str:
-    """Returns an acceptable SegmentName prefix
-    corresponding to the given NCBISourceMolType.
+    """Return an acceptable SegmentName prefix corresponding to
+    the given NCBISourceMolType.
     """
     if moltype in (
         NCBISourceMolType.GENOMIC_DNA,
@@ -56,16 +57,23 @@ def determine_segment_prefix(moltype: NCBISourceMolType) -> str:
     ):
         return "DNA"
 
+    prefix = ""
+
     match moltype:
         case NCBISourceMolType.GENOMIC_RNA:
-            return "RNA"
+            prefix = "RNA"
         case NCBISourceMolType.MRNA:
-            return "mRNA"
+            prefix = "mRNA"
         case NCBISourceMolType.TRNA:
-            return "tRNA"
+            prefix = "tRNA"
         case NCBISourceMolType.TRANSCRIBED_RNA:
-            return "RNA"
+            prefix = "RNA"
         case NCBISourceMolType.VIRAL_CRNA:
-            return "cRNA"
+            prefix = "cRNA"
         case NCBISourceMolType.OTHER_RNA:
-            return "RNA"
+            prefix = "RNA"
+
+    if prefix:
+        return prefix
+
+    raise ValueError(f"{moltype} may not be a valid NCBISourceMolType.")

--- a/ref_builder/schema.py
+++ b/ref_builder/schema.py
@@ -1,10 +1,11 @@
-import re
 from typing import NamedTuple
 
 from pydantic import BaseModel, UUID4, computed_field
 
 from ref_builder.models import Molecule
 from ref_builder.ncbi.models import NCBISourceMolType
+
+"""Regex pattern for parsing segment name strings containing both a prefix and a key."""
 
 
 class SegmentName(NamedTuple):
@@ -44,7 +45,10 @@ class OTUSchema(BaseModel):
         return len(self.segments) > 1
 
 
-def set_segment_prefix(moltype: NCBISourceMolType):
+def determine_segment_prefix(moltype: NCBISourceMolType) -> str:
+    """Returns an acceptable SegmentName prefix
+    corresponding to the given NCBISourceMolType.
+    """
     if moltype in (
         NCBISourceMolType.GENOMIC_DNA,
         NCBISourceMolType.OTHER_DNA,
@@ -65,17 +69,3 @@ def set_segment_prefix(moltype: NCBISourceMolType):
             return "cRNA"
         case NCBISourceMolType.OTHER_RNA:
             return "RNA"
-
-
-complex_name_pattern = re.compile(r"([A-Za-z]+)[-_ ]+([A-Za-z0-9]+)")
-
-
-def parse_segment_name(raw: str) -> SegmentName:
-    segment_name_parse = complex_name_pattern.fullmatch(raw)
-    if segment_name_parse:
-        return SegmentName(
-            prefix=segment_name_parse.group(1),
-            key=segment_name_parse.group(2)
-        )
-
-    raise ValueError(f"{raw} is not a valid segment name")

--- a/ref_builder/schema.py
+++ b/ref_builder/schema.py
@@ -11,6 +11,10 @@ class SegmentName(NamedTuple):
     prefix: str
     key: str
 
+    def __str__(self) -> str:
+        """Return the segment name as a formatted string."""
+        return f"{self.prefix} {self.key}"
+
 
 class Segment(BaseModel):
     """The metadata of the segment"""
@@ -62,8 +66,6 @@ def set_segment_prefix(moltype: NCBISourceMolType):
         case NCBISourceMolType.OTHER_RNA:
             return "RNA"
 
-
-simple_name_pattern = re.compile(r"([A-Za-z0-9])+")
 
 complex_name_pattern = re.compile(r"([A-Za-z]+)[-_ ]+([A-Za-z0-9]+)")
 

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -50,29 +50,15 @@
     'segments': list([
       dict({
         'length': 2575,
-        'name': 'DNA-A',
+        'name': 'DNA A',
         'required': True,
       }),
       dict({
         'length': 2494,
-        'name': 'DNA-B',
+        'name': 'DNA B',
         'required': True,
       }),
     ]),
-  })
-# ---
-# name: TestCreateOTUCommands.test_autofill_ok.1
-  dict({
-    'length': 2575,
-    'name': 'DNA A',
-    'required': True,
-  })
-# ---
-# name: TestCreateOTUCommands.test_autofill_ok.2
-  dict({
-    'length': 2494,
-    'name': 'DNA B',
-    'required': True,
   })
 # ---
 # name: TestCreateOTUCommands.test_ok[1278205-accessions0]
@@ -132,39 +118,11 @@
   })
 # ---
 # name: TestUpdateOTU.test_without_exclusions_ok
-  list([
-    dict({
-      'acronym': '',
-      'excluded_accessions': list([
-      ]),
-      'legacy_id': None,
-      'name': 'Apple rubbery wood virus 1',
-      'schema': dict({
-        'molecule': dict({
-          'strandedness': 'single',
-          'topology': 'linear',
-          'type': 'RNA',
-        }),
-        'multipartite': True,
-        'segments': list([
-          dict({
-            'length': 7219,
-            'name': 'RNA L',
-            'required': True,
-          }),
-          dict({
-            'length': 1613,
-            'name': 'RNA M',
-            'required': True,
-          }),
-          dict({
-            'length': 1291,
-            'name': 'RNA S',
-            'required': True,
-          }),
-        ]),
-      }),
-      'taxid': 2164102,
+  dict({
+    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='1148-13'): set({
+      'MF062130',
+      'MF062131',
+      'MF062132',
     }),
     IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='4342-5'): set({
       'MF062136',

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -16,12 +16,12 @@
       'segments': list([
         dict({
           'length': 2575,
-          'name': 'DNA-A',
+          'name': 'DNA A',
           'required': True,
         }),
         dict({
           'length': 2494,
-          'name': 'DNA-B',
+          'name': 'DNA B',
           'required': True,
         }),
       ]),
@@ -59,6 +59,20 @@
         'required': True,
       }),
     ]),
+  })
+# ---
+# name: TestCreateOTUCommands.test_autofill_ok.1
+  dict({
+    'length': 2575,
+    'name': 'DNA A',
+    'required': True,
+  })
+# ---
+# name: TestCreateOTUCommands.test_autofill_ok.2
+  dict({
+    'length': 2494,
+    'name': 'DNA B',
+    'required': True,
   })
 # ---
 # name: TestCreateOTUCommands.test_ok[1278205-accessions0]
@@ -104,12 +118,12 @@
       'segments': list([
         dict({
           'length': 2575,
-          'name': 'DNA-A',
+          'name': 'DNA A',
           'required': True,
         }),
         dict({
           'length': 2494,
-          'name': 'DNA-B',
+          'name': 'DNA B',
           'required': True,
         }),
       ]),
@@ -118,11 +132,39 @@
   })
 # ---
 # name: TestUpdateOTU.test_without_exclusions_ok
-  dict({
-    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='1148-13'): set({
-      'MF062130',
-      'MF062131',
-      'MF062132',
+  list([
+    dict({
+      'acronym': '',
+      'excluded_accessions': list([
+      ]),
+      'legacy_id': None,
+      'name': 'Apple rubbery wood virus 1',
+      'schema': dict({
+        'molecule': dict({
+          'strandedness': 'single',
+          'topology': 'linear',
+          'type': 'RNA',
+        }),
+        'multipartite': True,
+        'segments': list([
+          dict({
+            'length': 7219,
+            'name': 'RNA L',
+            'required': True,
+          }),
+          dict({
+            'length': 1613,
+            'name': 'RNA M',
+            'required': True,
+          }),
+          dict({
+            'length': 1291,
+            'name': 'RNA S',
+            'required': True,
+          }),
+        ]),
+      }),
+      'taxid': 2164102,
     }),
     IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='4342-5'): set({
       'MF062136',

--- a/tests/ref/test_schema.py
+++ b/tests/ref/test_schema.py
@@ -7,8 +7,12 @@ from syrupy.filters import props
 from ref_builder.ncbi.client import NCBIClient
 from ref_builder.ncbi.models import NCBISourceMolType
 from ref_builder.otu.update import create_schema_from_records
-from ref_builder.otu.utils import get_multipartite_segment_name, parse_segment_name
-from ref_builder.schema import OTUSchema, SegmentName
+from ref_builder.schema import (
+    OTUSchema,
+    SegmentName,
+    get_multipartite_segment_name,
+    parse_segment_name,
+)
 from tests.fixtures.factories import NCBIGenbankFactory, NCBISourceFactory
 
 

--- a/tests/ref/test_schema.py
+++ b/tests/ref/test_schema.py
@@ -7,8 +7,8 @@ from syrupy.filters import props
 from ref_builder.ncbi.models import NCBIGenbank
 from ref_builder.models import MolType
 from ref_builder.otu.update import create_schema_from_records
-from ref_builder.otu.utils import get_multipartite_segment_name
-from ref_builder.schema import SegmentName, OTUSchema, parse_segment_name
+from ref_builder.otu.utils import get_multipartite_segment_name, parse_segment_name
+from ref_builder.schema import SegmentName, OTUSchema
 
 
 class MockNCBISource:

--- a/tests/ref/test_schema.py
+++ b/tests/ref/test_schema.py
@@ -5,7 +5,7 @@ from syrupy import SnapshotAssertion
 from syrupy.filters import props
 
 from ref_builder.otu.update import create_schema_from_records
-from ref_builder.schema import OTUSchema, parse_segment_name
+from ref_builder.schema import SegmentName, OTUSchema, parse_segment_name
 
 
 @pytest.mark.parametrize(
@@ -42,9 +42,9 @@ class TestSegmentNameParser:
     @pytest.mark.parametrize(
         "expected_result, test_strings",
         [
-            ("A", ["A", "DNA A", "DNA_A", "DNA-A"]),
-            ("BN", ["BN", "RNA BN", "RNA_BN", "RNA-BN"]),
-            ("U3", ["U3", "DNA U3", "DNA U3", "DNA-U3"]),
+            (SegmentName(prefix="DNA", key="A"), ["DNA A", "DNA_A", "DNA-A"]),
+            (SegmentName(prefix="RNA", key="BN"), ["RNA BN", "RNA_BN", "RNA-BN"]),
+            (SegmentName(prefix="DNA", key="U3"), ["DNA U3", "DNA U3", "DNA-U3"]),
         ],
     )
     def test_ok(self, expected_result: str, test_strings: list[str]):
@@ -54,8 +54,6 @@ class TestSegmentNameParser:
             parse_segment_name(test_strings[1])
             ==
             parse_segment_name(test_strings[2])
-            ==
-            parse_segment_name(test_strings[3])
             ==
             expected_result
         )

--- a/tests/ref/test_schema.py
+++ b/tests/ref/test_schema.py
@@ -4,22 +4,12 @@ import pytest
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
 
-from ref_builder.ncbi.models import NCBIGenbank
 from ref_builder.models import MolType
+from ref_builder.ncbi.client import NCBIClient
+from ref_builder.ncbi.models import NCBIGenbank
 from ref_builder.otu.update import create_schema_from_records
 from ref_builder.otu.utils import get_multipartite_segment_name, parse_segment_name
-from ref_builder.schema import SegmentName, OTUSchema
-
-
-class MockNCBISource:
-    def __init__(self, segment_name: str):
-        self.segment = segment_name
-
-
-class MockNCBIGenbank:
-    def __init__(self, moltype: MolType, source: MockNCBISource):
-        self.moltype = moltype
-        self.source = source
+from ref_builder.schema import OTUSchema, SegmentName
 
 
 @pytest.mark.parametrize(
@@ -38,7 +28,7 @@ class MockNCBIGenbank:
 )
 def test_create_schema_from_records(
     accessions: list[str],
-    scratch_ncbi_client,
+    scratch_ncbi_client: NCBIClient,
     snapshot: SnapshotAssertion,
 ):
     records = scratch_ncbi_client.fetch_genbank_records(accessions)
@@ -53,6 +43,8 @@ def test_create_schema_from_records(
 
 
 class TestSegmentNameParser:
+    """Test different configurations of segment name."""
+
     @pytest.mark.parametrize(
         "expected_result, test_strings",
         [


### PR DESCRIPTION
Formats all multipartite segment names to `[PREFIX] [KEY]` where possible. Handles dashes, underscores and missing prefixes.

* add: `schema.SegmentName`
* add: `schema.get_multipartite_segment_name()`
* add: `schema.determine_segment_prefix()`
* add `TestSegmentNameParser`