### PR TITLE
fix: `update_otu_with_accessions()` adds RefSeq isolates correctly

### DIFF
--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -212,6 +212,27 @@ def update_otu_with_accessions(
 
     records = ncbi.fetch_genbank_records(accessions)
 
+    refseq_records, non_refseq_records = _file_refseq_and_non_refseq_records(records)
+
+    # Add remaining RefSeq records first
+    otu = repo.get_otu(otu.id)
+    file_records_into_otu(repo, otu, refseq_records)
+
+    # Add add non-RefSeq records last
+    otu = repo.get_otu(otu.id)
+    file_records_into_otu(repo, otu, non_refseq_records)
+
+
+def file_records_into_otu(
+    repo: Repo,
+    otu: RepoOTU,
+    records: list[NCBIGenbank],
+) -> list[IsolateName]:
+    """Take a list of GenBank records from NCBI Nucleotide and attempt to create new isolates.
+    If an isolate candidate does not match the schema, the constituent records are not added
+    to the OTU."""
+    otu_logger = logger.bind(taxid=otu.taxid, otu_id=str(otu.id), name=otu.name)
+
     record_bins = group_genbank_records_by_isolate(records)
 
     otu_logger.debug(
@@ -227,6 +248,7 @@ def update_otu_with_accessions(
             otu_logger.debug(
                 f"The schema requires {len(otu.schema.segments)} segments: "
                 + f"{[segment.name for segment in otu.schema.segments]}",
+                isolate_accessions=[accession.key for accession in isolate_records],
             )
             otu_logger.debug(f"Skipping {isolate_name}")
             continue
@@ -243,7 +265,10 @@ def update_otu_with_accessions(
     if new_isolate_names:
         otu_logger.info("New isolates added", new_isolates=new_isolate_names)
 
+        return new_isolate_names
+
     otu_logger.info("No new isolates added.")
+    return []
 
 
 def exclude_accessions_from_otu(
@@ -256,7 +281,7 @@ def exclude_accessions_from_otu(
     for accession in accessions:
         excluded_accessions = repo.exclude_accession(otu.id, accession)
 
-    logger.info(
+    logger.debug(
         f"Accessions currently excluded from fetches: {excluded_accessions}",
         taxid=otu.taxid,
         otu_id=str(otu.id),

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -212,7 +212,7 @@ def update_otu_with_accessions(
 
     records = ncbi.fetch_genbank_records(accessions)
 
-    refseq_records, non_refseq_records = _file_refseq_and_non_refseq_records(records)
+    refseq_records, non_refseq_records = _bin_refseq_records(records)
 
     # Add remaining RefSeq records first
     otu = repo.get_otu(otu.id)
@@ -322,3 +322,22 @@ def add_schema_from_accessions(
             molecule=schema.molecule,
             segments=schema.segments,
         )
+
+
+def _bin_refseq_records(
+    records: list[NCBIGenbank]) -> tuple[list[NCBIGenbank], list[NCBIGenbank]
+]:
+    """Returns a list of GenBank records as two lists, RefSeq and non-RefSeq."""
+    refseq_records = []
+    non_refseq_records = []
+
+    for record in records:
+        if record.refseq:
+            refseq_records.append(record)
+        else:
+            non_refseq_records.append(record)
+
+    if len(refseq_records) + len(non_refseq_records) != len(records):
+        raise ValueError("Invalid total number of records")
+
+    return refseq_records, non_refseq_records

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -110,39 +110,31 @@
   })
 # ---
 # name: TestUpdateOTU.test_without_exclusions_ok
-  list([
-    dict({
-      'acronym': '',
-      'excluded_accessions': list([
-      ]),
-      'legacy_id': None,
-      'name': 'Apple rubbery wood virus 1',
-      'schema': dict({
-        'molecule': dict({
-          'strandedness': 'single',
-          'topology': 'linear',
-          'type': 'RNA',
-        }),
-        'multipartite': True,
-        'segments': list([
-          dict({
-            'length': 7219,
-            'name': 'L',
-            'required': True,
-          }),
-          dict({
-            'length': 1613,
-            'name': 'M',
-            'required': True,
-          }),
-          dict({
-            'length': 1291,
-            'name': 'S',
-            'required': True,
-          }),
-        ]),
-      }),
-      'taxid': 2164102,
+  dict({
+    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='1148-13'): set({
+      'MF062130',
+      'MF062131',
+      'MF062132',
     }),
-  ])
+    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='4342-5'): set({
+      'MF062136',
+      'MF062137',
+      'MF062138',
+    }),
+    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='982-11'): set({
+      'NC_055390',
+      'NC_055391',
+      'NC_055392',
+    }),
+    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='BR-Mishima'): set({
+      'MK936225',
+      'MK936226',
+      'MK936227',
+    }),
+    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='Pe2'): set({
+      'OQ420743',
+      'OQ420744',
+      'OQ420745',
+    }),
+  })
 # ---

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -203,34 +203,41 @@ class TestUpdateOTU:
         precached_repo: Repo,
         snapshot: SnapshotAssertion,
     ):
-        otu = create_otu(
+        otu_before = create_otu(
             precached_repo,
             2164102,
             ["MF062136", "MF062137", "MF062138"],
             "",
         )
 
-        assert otu.accessions == {"MF062136", "MF062137", "MF062138"}
+        assert otu_before.accessions == {"MF062136", "MF062137", "MF062138"}
 
-        auto_update_otu(precached_repo, otu)
+        auto_update_otu(precached_repo, otu_before)
 
-        otu = precached_repo.get_otu(otu.id)
+        otu_after = precached_repo.get_otu(otu_before.id)
 
-        assert [otu.dict() for otu in precached_repo.iter_otus()] == snapshot(
-            exclude=props("id", "isolates", "repr_isolate"),
-        )
+        assert otu_after.id == otu_before.id
 
-        assert otu.accessions == {
+        assert otu_after.isolate_ids.issuperset(otu_before.isolate_ids)
+
+        assert {isolate.name: isolate.accessions for isolate in otu_after.isolates} == snapshot()
+
+        assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}
+
+        assert otu_after.accessions == {
             "MF062136",
             "MF062137",
             "MF062138",
             "MF062130",
             "MF062131",
             "MF062132",
-            "OQ420743",
-            "OQ420744",
-            "OQ420745",
             "MK936225",
             "MK936226",
             "MK936227",
+            "OQ420743",
+            "OQ420744",
+            "OQ420745",
+            "NC_055390",
+            "NC_055391",
+            "NC_055392",
         }


### PR DESCRIPTION
* move isolate/sequence creation from of `update_otu_with_accessions()` into `file_records_into_otu()` 
* add `_bin_refseq_records()` utility function
* `update_otu_with_accessions()` divides `records` into RefSeq and non-RefSeq lists and calls `file_records_into_otu()` for each automatically