### PR TITLE
Use Pydantic for more resources

### DIFF
--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -492,9 +492,10 @@ class Repo:
             elif isinstance(event, CreateIsolate):
                 otu.add_isolate(
                     RepoIsolate(
-                        uuid=event.data.id,
+                        id=event.data.id,
                         legacy_id=event.data.legacy_id,
                         name=event.data.name,
+                        sequences=[],
                     ),
                 )
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -468,13 +468,15 @@ class Repo:
             )
 
         otu = RepoOTU(
-            uuid=event.data.id,
+            id=event.data.id,
             acronym=event.data.acronym,
-            excluded_accessions=[],
+            excluded_accessions=set(),
+            isolates=[],
             legacy_id=event.data.legacy_id,
             name=event.data.name,
-            taxid=event.data.taxid,
+            repr_isolate=None,
             schema=event.data.otu_schema,
+            taxid=event.data.taxid,
         )
 
         for event_id in event_ids[1:]:
@@ -500,7 +502,7 @@ class Repo:
                 )
 
             elif isinstance(event, DeleteIsolate):
-                otu.remove_isolate(event.query.isolate_id)
+                otu.delete_isolate(event.query.isolate_id)
 
             elif isinstance(event, ExcludeAccession):
                 otu.excluded_accessions.add(event.data.accession)

--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -1,5 +1,4 @@
 import datetime
-from pprint import pprint
 from typing import Any
 from uuid import UUID
 
@@ -175,8 +174,6 @@ class RepoIsolate(BaseModel):
         return self._sequences_by_accession.get(accession)
 
     def get_sequence_by_id(self, sequence_id: UUID) -> RepoSequence | None:
-        pprint(self._sequences_by_id)
-
         if sequence_id not in self.sequence_ids:
             return None
 
@@ -187,96 +184,47 @@ class RepoIsolate(BaseModel):
         return None
 
 
-class RepoOTU:
+class RepoOTU(BaseModel):
     """Represents an OTU in a Virtool reference repository."""
 
-    def __init__(
-        self,
-        uuid: UUID4,
-        taxid: int,
-        name: str,
-        schema: OTUSchema,
-        acronym: str = "",
-        legacy_id: str | None = None,
-        excluded_accessions: list[str] | None = None,
-        isolates: list[RepoIsolate] | None = None,
-        repr_isolate: UUID4 | None = None,
-    ):
-        self.id = uuid
-        """The OTU id."""
+    id: UUID4
+    """The OTU id."""
 
-        self.taxid = taxid
-        """The NCBI Taxonomy id for this OTU."""
+    acronym: str
+    """The OTU acronym (eg. TMV for Tobacco mosaic virus)."""
 
-        self.name = name
-        """The name of the OTU (eg. TMV for Tobacco mosaic virus)"""
+    excluded_accessions: set[str]
+    """A set of accessions that should not be retrieved in future fetch operations."""
 
-        self.acronym = acronym
-        """The OTU acronym (eg. TMV for Tobacco mosaic virus)."""
+    isolates: list[RepoIsolate]
+    """Isolates contained in this OTU."""
 
-        self.legacy_id = legacy_id
-        """A string based ID carried over from a legacy Virtool reference repository."""
+    legacy_id: str | None
+    """A string based ID carried over from a legacy Virtool reference repository."""
 
-        self.schema = schema
-        """The schema of the OTU"""
+    name: str
+    """The name of the OTU (eg. TMV for Tobacco mosaic virus)"""
 
-        self.excluded_accessions = (
-            set() if excluded_accessions is None else set(excluded_accessions)
-        )
-        """A set of accessions that should not be retrieved
-        in future fetch operations"""
+    repr_isolate: UUID4 | None
+    """The UUID of the representative isolate of this OTU"""
 
-        self._isolates_by_id = (
-            {} if isolates is None else {isolate.id: isolate for isolate in isolates}
-        )
-        """A dictionary of isolates indexed by isolate UUID"""
+    schema: OTUSchema
+    """The schema of the OTU"""
 
-        self.repr_isolate = repr_isolate
-        """The UUID of the representative isolate of this OTU"""
+    taxid: int
+    """The NCBI Taxonomy id for this OTU."""
 
-        self.__hash__ = None
+    _isolates_by_id: dict[UUID4:RepoIsolate]
+    """A dictionary of isolates indexed by isolate UUID"""
 
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "RepoOTU":
-        """Build a new OTU from .dict() output."""
-        return RepoOTU(
-            uuid=data["id"],
-            taxid=data["taxid"],
-            name=data["name"],
-            acronym=data.get("acronym"),
-            schema=data.get("schema"),
-            isolates=data.get("isolates"),
-            repr_isolate=data.get("repr_isolate"),
-        )
-
-    @property
-    def isolates(self) -> list[RepoIsolate]:
-        """Isolates contained in this OTU."""
-        return list(self._isolates_by_id.values())
-
-    @property
-    def isolate_ids(self) -> set[UUID]:
-        """A set of UUIDs for isolates in the OTU."""
-        return set(self._isolates_by_id.keys())
+    def __init__(self, **data) -> None:
+        super().__init__(**data)
+        self._isolates_by_id = {isolate.id: isolate for isolate in self.isolates}
 
     @property
     def accessions(self) -> set[str]:
         """A set of accessions contained in this isolate."""
-        accessions = set()
-        for isolate in self.isolates:
-            accessions.update(isolate.accessions)
-
-        return accessions
-
-    @property
-    def sequence_ids(self) -> set[UUID]:
-        """A set of UUIDs for sequences in the OTU."""
-        sequence_ids = set()
-
-        for isolate in self.isolates:
-            sequence_ids.update(isolate.sequence_ids)
-
-        return sequence_ids
+        return set().union(*(isolate.accessions for isolate in self.isolates))
 
     @property
     def blocked_accessions(self) -> set[str]:
@@ -287,39 +235,37 @@ class RepoOTU:
         """
         return self.accessions | self.excluded_accessions
 
-    def __repr__(self) -> str:
-        """Return a shorthand representation of the OTU's contents."""
-        return (
-            f"EventSourcedRepoOTU(id='{self.id}', taxid='{self.taxid}', "
-            f"name={self.name}, "
-            f"schema={self.schema}, "
-            f"repr_isolate={self.repr_isolate}, "
-            f"accessions={list(self.accessions)})"
-        )
+    @property
+    def isolate_ids(self) -> set[UUID4]:
+        """A set of UUIDs for isolates in the OTU."""
+        return set(self._isolates_by_id.keys())
+
+    @property
+    def sequence_ids(self) -> set[UUID]:
+        """A set of UUIDs for sequences in the OTU."""
+        return set().union(*(isolate.sequence_ids for isolate in self.isolates))
 
     def add_isolate(self, isolate: RepoIsolate) -> None:
         """Add an isolate to the OTU."""
+        self.isolates.append(isolate)
         self._isolates_by_id[isolate.id] = isolate
 
     def add_sequence(self, sequence: RepoSequence, isolate_id: UUID4) -> None:
         """Add a sequence to a given isolate."""
-        self._isolates_by_id[isolate_id].add_sequence(sequence)
+        self.get_isolate(isolate_id).add_sequence(sequence)
 
-    def replace_sequence(
-        self,
-        sequence: RepoSequence,
-        isolate_id: UUID4,
-        replaced_sequence_id: UUID4,
-    ) -> None:
-        """Replace a sequence with the given ID with a new sequence."""
-        self._isolates_by_id[isolate_id].replace_sequence(
-            sequence,
-            replaced_sequence_id,
-        )
+    def delete_isolate(self, isolate_id: UUID4) -> None:
+        """Remove an isolate from the OTU."""
+        self._isolates_by_id.pop(isolate_id)
+
+        for isolate in self.isolates:
+            if isolate.id == isolate_id:
+                self.isolates.remove(isolate)
+                break
 
     def delete_sequence(self, sequence_id: UUID4, isolate_id: UUID4) -> None:
         """Delete a sequence from a given isolate. Used only for rehydration."""
-        self._isolates_by_id[isolate_id].delete_sequence(sequence_id)
+        self.get_isolate(isolate_id).delete_sequence(sequence_id)
 
     def get_isolate(self, isolate_id: UUID4) -> RepoIsolate | None:
         """Get isolate associated with a given ID.
@@ -331,9 +277,20 @@ class RepoOTU:
         """
         return self._isolates_by_id.get(isolate_id)
 
-    def remove_isolate(self, isolate_id: UUID4) -> None:
-        """Remove an isolate from the OTU."""
-        self._isolates_by_id.pop(isolate_id)
+    def get_isolate_id_by_name(self, name: IsolateName) -> UUID4 | None:
+        """Get the ID for the isolate with the passed ``name``.
+
+        Returns None if no such isolate exists.
+
+        :param name: The name of the isolate to retrieve
+        :return: The isolate ID or ``None``
+
+        """
+        for isolate in self.isolates:
+            if isolate.name == name:
+                return isolate.id
+
+        return None
 
     def get_sequence_by_accession(
         self,
@@ -365,55 +322,11 @@ class RepoOTU:
 
         raise ValueError(f"Accession {accession} found in index, but not in data")
 
-    def get_isolate_id_by_name(self, name: IsolateName) -> UUID4 | None:
-        """Get the ID for the isolate with the passed ``name``.
-
-        Returns None if no such isolate exists.
-
-        :param name: The name of the isolate to retrieve
-        :return: The isolate ID or ``None``
-
-        """
-        for isolate in self.isolates:
-            if isolate.name == name:
-                return isolate.id
-
-        return None
-
-    def dict(self, exclude_contents: bool = False):
-        otu_dict = {
-            "id": self.id,
-            "acronym": self.acronym,
-            "excluded_accessions": list(self.excluded_accessions),
-            "repr_isolate": self.repr_isolate,
-            "legacy_id": self.legacy_id,
-            "name": self.name,
-            "schema": self.schema.model_dump() if self.schema is not None else None,
-            "taxid": self.taxid,
-        }
-
-        if not exclude_contents:
-            otu_dict["isolates"] = [
-                isolate.model_dump(exclude={"sequences"}) for isolate in self.isolates
-            ]
-
-        return otu_dict
-
-    def __eq__(self, other: "RepoOTU") -> bool:
-        """Check if this OTU is equal to ``other``."""
-        for isolate_id in self.isolate_ids:
-            if self.get_isolate(isolate_id) != other.get_isolate(isolate_id):
-                return False
-
-        return (
-            isinstance(other, RepoOTU)
-            and self.accessions == other.accessions
-            and self.acronym == other.acronym
-            and self.id == other.id
-            and self.isolate_ids == other.isolate_ids
-            and self.legacy_id == other.legacy_id
-            and self.name == other.name
-            and self.taxid == other.taxid
-            and self.repr_isolate == other.repr_isolate
-            and self.schema == other.schema
-        )
+    def replace_sequence(
+        self,
+        sequence: RepoSequence,
+        isolate_id: UUID4,
+        replaced_sequence_id: UUID4,
+    ) -> None:
+        """Replace a sequence with the given ID with a new sequence."""
+        self.get_isolate(isolate_id).replace_sequence(sequence, replaced_sequence_id)

--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -106,8 +106,6 @@ class RepoIsolate:
         It the isolate was not migrated from a legacy repository, this will be `None`.
         """
 
-        self.__hash__ = None
-
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "RepoIsolate":
         """Build a new isolate from .dict() output."""

--- a/ref_builder/snapshotter/otu.py
+++ b/ref_builder/snapshotter/otu.py
@@ -143,7 +143,8 @@ class OTUSnapshotDataStore:
         indent: int | None = None,
     ):
         """Serialize and cache a sequence to the data store."""
-        validated_sequence = OTUSnapshotSequence(**sequence.dict())
+        validated_sequence = OTUSnapshotSequence(**sequence.model_dump())
+
         with open(self.path / f"{sequence.id}.json", "w") as f:
             f.write(validated_sequence.model_dump_json(indent=indent))
 
@@ -202,7 +203,9 @@ class OTUSnapshot:
         self._metadata.at_event = at_event
 
         try:
-            validated_otu = OTUSnapshotOTU.model_validate(otu.dict(exclude_contents=True))
+            validated_otu = OTUSnapshotOTU.model_validate(
+                otu.dict(exclude_contents=True),
+            )
         except ValidationError:
             msg = f"{otu.dict(exclude_contents=True)} is not a valid OTU."
             raise ValueError(msg)

--- a/ref_builder/snapshotter/otu.py
+++ b/ref_builder/snapshotter/otu.py
@@ -128,7 +128,9 @@ class OTUSnapshotDataStore:
         indent: int | None = None,
     ):
         """Serialize and cache an isolate to the data store."""
-        validated_isolate = OTUSnapshotIsolate(**isolate.dict(exclude_contents=True))
+        validated_isolate = OTUSnapshotIsolate(
+            **isolate.model_dump(exclude={"sequences"}),
+        )
         with open(self.path / f"{isolate.id}.json", "w") as f:
             f.write(validated_isolate.model_dump_json(indent=indent))
 
@@ -259,12 +261,9 @@ class OTUSnapshot:
 
                 sequences.append(sequence)
 
-            isolate_dict = isolate_structure.model_dump()
-            isolate_dict["uuid"] = isolate_dict.pop("id")
-
-            isolate = RepoIsolate(**isolate_dict, sequences=sequences)
-
-            isolates.append(isolate)
+            isolates.append(
+                RepoIsolate(**isolate_structure.model_dump(), sequences=sequences)
+            )
 
         otu_dict = otu_structure.model_dump(by_alias=True)
         otu_dict["excluded_accessions"] = excluded_accessions

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -2,8 +2,8 @@
 # name: TestCreateOTU.test_empty_success
   dict({
     'acronym': '',
-    'excluded_accessions': list([
-    ]),
+    'excluded_accessions': set({
+    }),
     'legacy_id': None,
     'name': 'Cabbage leaf curl Jamaica virus',
     'schema': dict({
@@ -56,9 +56,9 @@
 # name: TestCreateOTUCommands.test_ok[1278205-accessions0]
   dict({
     'acronym': '',
-    'excluded_accessions': list([
+    'excluded_accessions': set({
       'JX263426',
-    ]),
+    }),
     'legacy_id': None,
     'name': 'Dahlia latent viroid',
     'schema': dict({
@@ -82,8 +82,8 @@
 # name: TestCreateOTUCommands.test_ok[345184-accessions1]
   dict({
     'acronym': '',
-    'excluded_accessions': list([
-    ]),
+    'excluded_accessions': set({
+    }),
     'legacy_id': None,
     'name': 'Cabbage leaf curl Jamaica virus',
     'schema': dict({
@@ -113,8 +113,8 @@
   list([
     dict({
       'acronym': '',
-      'excluded_accessions': list([
-      ]),
+      'excluded_accessions': set({
+      }),
       'legacy_id': None,
       'name': 'Apple rubbery wood virus 1',
       'schema': dict({

--- a/tests/snapshotter/test_models.py
+++ b/tests/snapshotter/test_models.py
@@ -22,10 +22,9 @@ def test_otu_model_adherence(scratch_repo: Repo):
     otu_fields = set(otu.dict().keys())
 
     otu_fields.remove("isolates")
-
     otu_fields.remove("excluded_accessions")
-
     otu_fields.remove("schema")
+
     otu_fields.add("otu_schema")
 
     for field in otu_fields:
@@ -82,10 +81,9 @@ class TestRepoToSnapshotModel:
 
         for isolate in otu.isolates:
             assert type(isolate) is RepoIsolate
-
-            converted_model = OTUSnapshotIsolate(**isolate.dict())
-
-            assert converted_model.model_dump() == snapshot(exclude=props("id"))
+            assert OTUSnapshotIsolate(**isolate.model_dump()).model_dump() == snapshot(
+                exclude=props("id"),
+            )
 
     @pytest.mark.parametrize("taxid", [1441799, 430059])
     def test_otu_conversion(

--- a/tests/snapshotter/test_models.py
+++ b/tests/snapshotter/test_models.py
@@ -19,7 +19,7 @@ def test_otu_model_adherence(scratch_repo: Repo):
     """Check the OTU snapshot model for missing fields relative to RepoOTU."""
     otu = scratch_repo.get_otu_by_taxid(1169032)
 
-    otu_fields = set(otu.dict().keys())
+    otu_fields = set(otu.model_dump().keys())
 
     otu_fields.remove("isolates")
     otu_fields.remove("excluded_accessions")
@@ -96,7 +96,7 @@ class TestRepoToSnapshotModel:
 
         assert type(otu) is RepoOTU
 
-        converted_model = OTUSnapshotOTU(**otu.dict())
+        converted_model = OTUSnapshotOTU(**otu.model_dump())
 
         assert converted_model.id == otu.id
 

--- a/tests/snapshotter/test_models.py
+++ b/tests/snapshotter/test_models.py
@@ -103,7 +103,5 @@ class TestRepoToSnapshotModel:
         assert converted_model.id == otu.id
 
         assert converted_model.model_dump(by_alias=True) == snapshot(
-            exclude=props("id", "repr_isolate")
+            exclude=props("id", "repr_isolate"),
         )
-
-

--- a/tests/snapshotter/test_otu.py
+++ b/tests/snapshotter/test_otu.py
@@ -3,6 +3,7 @@ from uuid import UUID
 import orjson
 import pytest
 
+from ref_builder.repo import Repo
 from ref_builder.snapshotter.otu import OTUSnapshot
 
 
@@ -51,7 +52,7 @@ class TestOTUSnapshot:
 
         assert type(metadata_dict["at_event"]) is int
 
-    def test_load(self, taxid: int, scratch_repo):
+    def test_load(self, taxid: int, scratch_repo: Repo):
         """Test OTUSnapshot.load()"""
         rehydrated_otu = scratch_repo.get_otu_by_taxid(taxid)
 
@@ -67,7 +68,7 @@ class TestOTUSnapshot:
 
         assert rehydrated_otu.accessions == snapshot_otu.accessions
 
-    def test_toc(self, taxid: int,scratch_repo):
+    def test_toc(self, taxid: int, scratch_repo):
         """Test that the table of contents is written correctly."""
         rehydrated_otu = scratch_repo.get_otu_by_taxid(taxid)
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -106,32 +106,30 @@ class TestCreateOTU:
             taxid=12242,
         )
 
-        assert (
-            otu.dict()
-            == RepoOTU(
-                uuid=otu.id,
-                acronym="TMV",
-                excluded_accessions=None,
-                legacy_id="abcd1234",
-                name="Tobacco mosaic virus",
-                schema=OTUSchema(
-                    molecule=Molecule(
-                        strandedness=Strandedness.SINGLE,
-                        type=MolType.RNA,
-                        topology=Topology.LINEAR,
-                    ),
-                    segments=[
-                        Segment(
-                            id=otu.schema.segments[0].id,
-                            name="A",
-                            required=True,
-                            length=100,
-                        ),
-                    ],
+        assert otu == RepoOTU(
+            id=otu.id,
+            acronym="TMV",
+            excluded_accessions=set(),
+            legacy_id="abcd1234",
+            name="Tobacco mosaic virus",
+            repr_isolate=None,
+            schema=OTUSchema(
+                molecule=Molecule(
+                    strandedness=Strandedness.SINGLE,
+                    type=MolType.RNA,
+                    topology=Topology.LINEAR,
                 ),
-                taxid=12242,
-                isolates=[],
-            ).dict()
+                segments=[
+                    Segment(
+                        id=otu.schema.segments[0].id,
+                        name="A",
+                        required=True,
+                        length=100,
+                    ),
+                ],
+            ),
+            taxid=12242,
+            isolates=[],
         )
 
         with open(empty_repo.path.joinpath("src", "00000002.json")) as f:
@@ -460,27 +458,25 @@ class TestRetrieveOTU:
             ),
         ]
 
-        assert (
-            otu.dict()
-            == RepoOTU(
-                uuid=otu.id,
-                acronym="TMV",
-                excluded_accessions=[],
-                legacy_id=None,
-                name="Tobacco mosaic virus",
-                schema=OTUSchema(
-                    molecule=Molecule(
-                        strandedness=Strandedness.SINGLE,
-                        type=MolType.RNA,
-                        topology=Topology.LINEAR,
-                    ),
-                    segments=[
-                        Segment(id=otu.schema.segments[0].id, name="A", required=True),
-                    ],
+        assert otu == RepoOTU(
+            id=otu.id,
+            acronym="TMV",
+            excluded_accessions=set(),
+            legacy_id=None,
+            name="Tobacco mosaic virus",
+            repr_isolate=None,
+            schema=OTUSchema(
+                molecule=Molecule(
+                    strandedness=Strandedness.SINGLE,
+                    type=MolType.RNA,
+                    topology=Topology.LINEAR,
                 ),
-                taxid=12242,
-                isolates=otu_contents,
-            ).dict()
+                segments=[
+                    Segment(id=otu.schema.segments[0].id, name="A", required=True),
+                ],
+            ),
+            taxid=12242,
+            isolates=otu_contents,
         )
 
         assert empty_repo.last_id == 6

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -99,8 +99,8 @@ class TestCreateOTU:
                         id=uuid4(),
                         name="A",
                         required=True,
-                        length=100
-                    )
+                        length=100,
+                    ),
                 ],
             ),
             taxid=12242,
@@ -124,8 +124,9 @@ class TestCreateOTU:
                         Segment(
                             id=otu.schema.segments[0].id,
                             name="A",
-                            required=True, length=100
-                        )
+                            required=True,
+                            length=100,
+                        ),
                     ],
                 ),
                 taxid=12242,
@@ -155,8 +156,8 @@ class TestCreateOTU:
                             "id": str(otu.schema.segments[0].id),
                             "length": 100,
                             "name": "A",
-                            "required": True
-                        }
+                            "required": True,
+                        },
                     ],
                     "multipartite": False,
                 },
@@ -186,7 +187,7 @@ class TestCreateOTU:
                     topology=Topology.LINEAR,
                 ),
                 segments=[
-                    Segment(id=uuid4(), name="A", required=True)
+                    Segment(id=uuid4(), name="A", required=True),
                 ],
             ),
             taxid=12242,
@@ -206,7 +207,9 @@ class TestCreateOTU:
                         type=MolType.RNA,
                         topology=Topology.LINEAR,
                     ),
-                    segments=[Segment(id=otu.schema.segments[0].id, name="A", required=True)],
+                    segments=[
+                        Segment(id=otu.schema.segments[0].id, name="A", required=True),
+                    ],
                 ),
                 taxid=438782,
             )
@@ -244,7 +247,9 @@ class TestCreateOTU:
                         type=MolType.RNA,
                         topology=Topology.LINEAR,
                     ),
-                    segments=[Segment(id=otu.schema.segments[0].id, name="A", required=True)],
+                    segments=[
+                        Segment(id=otu.schema.segments[0].id, name="A", required=True),
+                    ],
                 ),
                 taxid=438782,
             )
@@ -424,7 +429,7 @@ class TestRetrieveOTU:
 
         otu_contents = [
             RepoIsolate(
-                uuid=isolate_a.id,
+                id=isolate_a.id,
                 legacy_id=None,
                 name=IsolateName(type=IsolateNameType.ISOLATE, value="A"),
                 sequences=[
@@ -439,7 +444,7 @@ class TestRetrieveOTU:
                 ],
             ),
             RepoIsolate(
-                uuid=isolate_b.id,
+                id=isolate_b.id,
                 legacy_id=None,
                 name=IsolateName(type=IsolateNameType.ISOLATE, value="B"),
                 sequences=[
@@ -469,7 +474,9 @@ class TestRetrieveOTU:
                         type=MolType.RNA,
                         topology=Topology.LINEAR,
                     ),
-                    segments=[Segment(id=otu.schema.segments[0].id, name="A", required=True)],
+                    segments=[
+                        Segment(id=otu.schema.segments[0].id, name="A", required=True),
+                    ],
                 ),
                 taxid=12242,
                 isolates=otu_contents,

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -2,10 +2,10 @@ from uuid import uuid4
 
 import pytest
 
-from ref_builder.resources import RepoIsolate, RepoOTU, RepoSequence
+from ref_builder.models import Molecule, MolType, Strandedness, Topology
+from ref_builder.resources import RepoIsolate, RepoOTU
 from ref_builder.schema import OTUSchema, Segment
 from ref_builder.utils import IsolateName, IsolateNameType
-from ref_builder.models import Molecule, MolType, Topology, Strandedness
 
 
 class TestSequence:
@@ -23,13 +23,9 @@ class TestSequence:
         otu = scratch_repo.get_otu_by_taxid(taxid)
 
         for accession in accessions:
-            sequence = otu.get_sequence_by_accession(accession)
-
-            assert type(sequence) is RepoSequence
-
-            sequence_copy = RepoSequence.from_dict(sequence.dict())
-
-            assert sequence == sequence_copy
+            assert otu.get_sequence_by_accession(
+                accession
+            ) == otu.get_sequence_by_accession(accession)
 
 
 class TestIsolate:
@@ -72,8 +68,8 @@ class TestOTU:
                     topology=Topology.LINEAR,
                 ),
                 segments=[
-                    Segment(id=uuid4(), name="genomic RNA", length=6395, required=True)
-                ]
+                    Segment(id=uuid4(), name="genomic RNA", length=6395, required=True),
+                ],
             ),
         )
 
@@ -93,7 +89,7 @@ class TestOTU:
             schema=otu.schema,
             excluded_accessions=otu.excluded_accessions,
             isolates=otu.isolates,
-            repr_isolate=otu.repr_isolate
+            repr_isolate=otu.repr_isolate,
         )
 
         assert otu == otu_copy
@@ -102,7 +98,9 @@ class TestOTU:
     def test_get_sequence_id_hierarchy(self, taxid, accession, scratch_repo):
         otu = scratch_repo.get_otu_by_taxid(taxid)
 
-        isolate_id, sequence_id = otu.get_sequence_id_hierarchy_from_accession(accession)
+        isolate_id, sequence_id = otu.get_sequence_id_hierarchy_from_accession(
+            accession
+        )
 
         assert otu.get_isolate(isolate_id) is not None
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -24,7 +24,7 @@ class TestSequence:
 
         for accession in accessions:
             assert otu.get_sequence_by_accession(
-                accession
+                accession,
             ) == otu.get_sequence_by_accession(accession)
 
 
@@ -32,8 +32,10 @@ class TestIsolate:
     def test_no_sequences(self):
         """Test that an isolate intializes correctly with no sequences."""
         isolate = RepoIsolate(
-            uuid=uuid4(),
+            id=uuid4(),
+            legacy_id=None,
             name=IsolateName(type=IsolateNameType.ISOLATE, value="A"),
+            sequences=[],
         )
 
         assert isolate.sequences == []
@@ -44,14 +46,7 @@ class TestIsolate:
         otu = scratch_repo.get_otu_by_taxid(taxid)
 
         for isolate in otu.isolates:
-            isolate_copy = RepoIsolate(
-                uuid=isolate.id,
-                name=isolate.name,
-                legacy_id=isolate.legacy_id,
-                sequences=isolate.sequences,
-            )
-
-            assert isolate == isolate_copy
+            assert isolate == otu.get_isolate(isolate.id)
 
 
 class TestOTU:
@@ -99,7 +94,7 @@ class TestOTU:
         otu = scratch_repo.get_otu_by_taxid(taxid)
 
         isolate_id, sequence_id = otu.get_sequence_id_hierarchy_from_accession(
-            accession
+            accession,
         )
 
         assert otu.get_isolate(isolate_id) is not None


### PR DESCRIPTION
Convert `RepoSequence`, `RepoIsolate`, `RepoOTU` to Pydantic models.

Having these as custom classes or dataclasses is causing problems for cleanly serializing their data.

