### PR TITLE
ECO-60: add override flag to `add isolate`

### DIFF
--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -214,6 +214,30 @@ def otu_promote_accessions(
     type=str,
     required=True,
 )
+@click.option(
+    "--ignore-name",
+    is_flag=True,
+    default=False,
+    help="Ignore isolate names in Genbank sources.",
+)
+@click.option(
+    "--isolate-type",
+    default=None,
+    help="an overriding type for the isolate",
+    type=click.Choice(
+        [
+            None,
+            IsolateNameType.ISOLATE,
+            IsolateNameType.STRAIN,
+            IsolateNameType.CLONE,
+        ]
+    ),
+)
+@click.option(
+    "--isolate-name",
+    help="an overriding name for the isolate",
+    type=str,
+)
 @ignore_cache_option
 @debug_option
 @click.pass_context
@@ -222,6 +246,9 @@ def isolate_create(
     debug: bool,
     ignore_cache: bool,
     accessions_: list[str],
+    ignore_name: bool,
+    isolate_type: IsolateNameType | None,
+    isolate_name: str | None = None,
 ) -> None:
     """Create a new isolate using the given accessions."""
     configure_logger(debug)
@@ -241,6 +268,8 @@ def isolate_create(
             otu_,
             accessions_,
             ignore_cache=ignore_cache,
+            ignore_name=ignore_name,
+            isolate_name=None if isolate_name is None else IsolateName(type=isolate_type, value=isolate_name),
         )
     except RefSeqConflictError as err:
         click.echo(

--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -215,13 +215,13 @@ def otu_promote_accessions(
     required=True,
 )
 @click.option(
-    "--ignore-name",
+    "--unnamed",
     is_flag=True,
     default=False,
     help="ignore isolate names in Genbank sources",
 )
 @click.option(
-    "--isolate-name",
+    "--name",
     type=(IsolateNameType, str),
     help='an overriding name for the isolate, e.g. "isolate ARWV1"',
 )
@@ -233,8 +233,8 @@ def isolate_create(
     debug: bool,
     ignore_cache: bool,
     accessions_: list[str],
-    ignore_name: bool,
-    isolate_name: tuple[IsolateNameType, str] | None,
+    unnamed: bool,
+    name: tuple[IsolateNameType, str] | None,
 ) -> None:
     """Create a new isolate using the given accessions."""
     configure_logger(debug)
@@ -249,8 +249,8 @@ def isolate_create(
         sys.exit(1)
 
     isolate_name_ = None
-    if isolate_name is not None:
-        isolate_name_type, isolate_name_value = isolate_name
+    if name is not None:
+        isolate_name_type, isolate_name_value = name
         isolate_name_ = IsolateName(type=isolate_name_type, value=isolate_name_value)
 
     try:
@@ -259,7 +259,7 @@ def isolate_create(
             otu_,
             accessions_,
             ignore_cache=ignore_cache,
-            ignore_name=ignore_name,
+            ignore_name=unnamed,
             isolate_name=isolate_name_,
         )
     except RefSeqConflictError as err:
@@ -286,7 +286,6 @@ def isolate_create(
 def accession_exclude(
     ctx,
     debug: bool,
-    ignore_cache: bool,
     accessions_: list[str],
 ) -> None:
     """Exclude the given accessions from this OTU."""

--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -221,22 +221,9 @@ def otu_promote_accessions(
     help="ignore isolate names in Genbank sources",
 )
 @click.option(
-    "--isolate-type",
-    default=None,
-    help="an overriding type for the isolate if --ignore-name is true",
-    type=click.Choice(
-        [
-            None,
-            IsolateNameType.ISOLATE,
-            IsolateNameType.STRAIN,
-            IsolateNameType.CLONE,
-        ]
-    ),
-)
-@click.option(
     "--isolate-name",
-    help="an overriding name for the isolate if --ignore-name is true",
-    type=str,
+    type=(IsolateNameType, str),
+    help='an overriding name for the isolate, e.g. "isolate ARWV1"',
 )
 @ignore_cache_option
 @debug_option
@@ -247,8 +234,7 @@ def isolate_create(
     ignore_cache: bool,
     accessions_: list[str],
     ignore_name: bool,
-    isolate_type: IsolateNameType | None,
-    isolate_name: str | None,
+    isolate_name: tuple[IsolateNameType, str] | None,
 ) -> None:
     """Create a new isolate using the given accessions."""
     configure_logger(debug)
@@ -262,6 +248,11 @@ def isolate_create(
         click.echo(f"OTU {taxid} not found.", err=True)
         sys.exit(1)
 
+    isolate_name_ = None
+    if isolate_name is not None:
+        isolate_name_type, isolate_name_value = isolate_name
+        isolate_name_ = IsolateName(type=isolate_name_type, value=isolate_name_value)
+
     try:
         add_isolate(
             repo,
@@ -269,11 +260,7 @@ def isolate_create(
             accessions_,
             ignore_cache=ignore_cache,
             ignore_name=ignore_name,
-            isolate_name=(
-                IsolateName(type=isolate_type, value=isolate_name)
-                if (ignore_name and isolate_type) is not None and isolate_name
-                else None
-            ),
+            isolate_name=isolate_name_,
         )
     except RefSeqConflictError as err:
         click.echo(

--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -218,12 +218,12 @@ def otu_promote_accessions(
     "--ignore-name",
     is_flag=True,
     default=False,
-    help="Ignore isolate names in Genbank sources.",
+    help="ignore isolate names in Genbank sources",
 )
 @click.option(
     "--isolate-type",
     default=None,
-    help="an overriding type for the isolate",
+    help="an overriding type for the isolate if --ignore-name is true",
     type=click.Choice(
         [
             None,
@@ -235,7 +235,7 @@ def otu_promote_accessions(
 )
 @click.option(
     "--isolate-name",
-    help="an overriding name for the isolate",
+    help="an overriding name for the isolate if --ignore-name is true",
     type=str,
 )
 @ignore_cache_option
@@ -248,7 +248,7 @@ def isolate_create(
     accessions_: list[str],
     ignore_name: bool,
     isolate_type: IsolateNameType | None,
-    isolate_name: str | None = None,
+    isolate_name: str | None,
 ) -> None:
     """Create a new isolate using the given accessions."""
     configure_logger(debug)
@@ -269,7 +269,11 @@ def isolate_create(
             accessions_,
             ignore_cache=ignore_cache,
             ignore_name=ignore_name,
-            isolate_name=None if isolate_name is None else IsolateName(type=isolate_type, value=isolate_name),
+            isolate_name=(
+                IsolateName(type=isolate_type, value=isolate_name)
+                if (ignore_name and isolate_type) is not None and isolate_name
+                else None
+            ),
         )
     except RefSeqConflictError as err:
         click.echo(

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -64,14 +64,21 @@ def add_isolate(
         return create_isolate_from_records(
             repo,
             otu,
+            isolate_name=None,
+            records=records,
+        )
+
+    if isolate_name:
+        return create_isolate_from_records(
+            repo,
+            otu,
             isolate_name=isolate_name,
             records=records,
         )
 
     record_bins = group_genbank_records_by_isolate(records)
     if len(record_bins) != 1:
-        otu_logger.warning("More than one isolate name found in requested accession.")
-        # Override later
+        otu_logger.error("More than one isolate name found in requested accession.")
         return None
 
     isolate_name, isolate_records = list(record_bins.items())[0]
@@ -94,7 +101,6 @@ def add_isolate(
                     isolate_name=isolate_name,
                     accessions=accessions,
                 )
-
             return None
 
     return create_isolate_from_records(

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -638,10 +638,12 @@ def _bin_refseq_records(
 
 
 def _create_fetch_list(
-    linked_accessions: list | set,
+    requested_accessions: list | set,
     blocked_accessions: set,
 ) -> list[str]:
-    fetch_list = list(set(linked_accessions).difference(blocked_accessions))
+    """Return the difference between a set of requested accessions and a set of blocked accessions.
+    Raise a ValueError if the intersection is complete."""
+    fetch_list = list(set(requested_accessions).difference(blocked_accessions))
     if fetch_list:
         return fetch_list
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -255,7 +255,24 @@ class TestAddIsolate:
 
         assert isolate_after.accessions == {"DQ178613", "DQ178614"}
 
-    def test_ignore_name_override_ok(self, precached_repo: Repo):
+    @pytest.mark.parametrize(
+        "expected_name, ignore_name, isolate_name",
+        [
+            (None, True, None),
+            (
+                IsolateName(type=IsolateNameType.ISOLATE, value="dummy"),
+                True,
+                IsolateName(type=IsolateNameType.ISOLATE, value="dummy")
+            ),
+            (
+                None,
+                True,
+                IsolateName(type=IsolateNameType.ISOLATE, value="dummy")
+            ),
+        ]
+    )
+    def test_ignore_name_override_ok(
+        self, precached_repo: Repo, expected_name: IsolateName | None, ignore_name: bool, isolate_name: IsolateName | None):
         """Test that ignore_name flag works as planned."""
         isolate_1_accessions = ["DQ178610", "DQ178611"]
         isolate_2_accessions = ["DQ178613", "DQ178614"]
@@ -268,7 +285,6 @@ class TestAddIsolate:
             precached_repo,
             otu,
             isolate_2_accessions,
-            ignore_name=True,
             isolate_name=IsolateName(type=IsolateNameType.ISOLATE, value="dummy")
         )
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -9,7 +9,9 @@ from syrupy.filters import props
 from ref_builder.otu.create import create_otu
 from ref_builder.otu.update import (
     auto_update_otu,
-    add_isolate,
+    add_genbank_isolate,
+    add_unnamed_isolate,
+    add_and_name_isolate,
     delete_isolate_from_otu,
     replace_sequence_in_otu,
     update_isolate_from_accessions,
@@ -226,7 +228,7 @@ class TestAddIsolate:
 
         assert otu.accessions == set(isolate_1_accessions)
 
-        isolate = add_isolate(precached_repo, otu, isolate_2_accessions)
+        isolate = add_genbank_isolate(precached_repo, otu, isolate_2_accessions)
 
         otu = precached_repo.get_otu_by_taxid(345184)
 
@@ -243,7 +245,7 @@ class TestAddIsolate:
 
         assert otu.accessions == set(isolate_1_accessions)
 
-        isolate = add_isolate(precached_repo, otu, isolate_2_accessions, ignore_name=True)
+        isolate = add_unnamed_isolate(precached_repo, otu, isolate_2_accessions)
 
         otu_after = precached_repo.get_otu_by_taxid(345184)
 
@@ -281,7 +283,7 @@ class TestAddIsolate:
 
         assert otu.accessions == set(isolate_1_accessions)
 
-        isolate = add_isolate(
+        isolate = add_and_name_isolate(
             precached_repo,
             otu,
             isolate_2_accessions,
@@ -311,7 +313,7 @@ class TestAddIsolate:
             "",
         )
 
-        assert add_isolate(precached_repo, otu, accessions) is None
+        assert add_genbank_isolate(precached_repo, otu, accessions) is None
 
 
 @pytest.mark.ncbi()
@@ -472,10 +474,10 @@ class TestReplaceIsolateSequences:
 
         assert otu_before.accessions == set(original_accessions)
 
-        add_isolate(empty_repo, otu_before, original_accessions)
+        add_genbank_isolate(empty_repo, otu_before, original_accessions)
 
         with pytest.raises(RefSeqConflictError):
-            add_isolate(empty_repo, otu_before, refseq_accessions)
+            add_genbank_isolate(empty_repo, otu_before, refseq_accessions)
 
 
 class TestRemoveIsolate:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -220,7 +220,8 @@ class TestCreateOTUCommands:
 
 
 class TestAddIsolate:
-    def test_ok(self, precached_repo: Repo):
+    def test_genbank_ok(self, precached_repo: Repo):
+        """Test that add_genbank_isolate() adds an isolate with a correctly parsed name."""
         isolate_1_accessions = ["DQ178610", "DQ178611"]
         isolate_2_accessions = ["DQ178613", "DQ178614"]
 
@@ -230,14 +231,18 @@ class TestAddIsolate:
 
         isolate = add_genbank_isolate(precached_repo, otu, isolate_2_accessions)
 
-        otu = precached_repo.get_otu_by_taxid(345184)
+        otu_after = precached_repo.get_otu_by_taxid(345184)
 
-        assert otu.accessions == set(isolate_1_accessions).union(set(isolate_2_accessions))
+        assert otu_after.accessions == set(isolate_1_accessions).union(set(isolate_2_accessions))
 
-        assert otu.get_isolate(isolate.id).accessions == set(isolate_2_accessions)
+        isolate_after = otu_after.get_isolate(isolate.id)
+
+        assert isolate_after.accessions == set(isolate_2_accessions)
+
+        assert isolate_after.name == IsolateName(IsolateNameType.ISOLATE, "Douglas Castle")
 
     def test_ignore_name_ok(self, precached_repo: Repo):
-        """Test that ignore_name flag works as planned."""
+        """Test that add_unnamed_isolate() adds the correct isolate with its name set to None."""
         isolate_1_accessions = ["DQ178610", "DQ178611"]
         isolate_2_accessions = ["DQ178613", "DQ178614"]
 
@@ -257,8 +262,8 @@ class TestAddIsolate:
 
         assert isolate_after.accessions == {"DQ178613", "DQ178614"}
 
-    def test_name_override_ok(self, precached_repo: Repo):
-        """Test that ignore_name flag works as planned."""
+    def test_add_and_name_ok(self, precached_repo: Repo):
+        """Test that add_and_name_isolate() creates an isolate with the correct name."""
         isolate_1_accessions = ["DQ178610", "DQ178611"]
         isolate_2_accessions = ["DQ178613", "DQ178614"]
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -257,24 +257,7 @@ class TestAddIsolate:
 
         assert isolate_after.accessions == {"DQ178613", "DQ178614"}
 
-    @pytest.mark.parametrize(
-        "expected_name, ignore_name, isolate_name",
-        [
-            (None, True, None),
-            (
-                IsolateName(type=IsolateNameType.ISOLATE, value="dummy"),
-                True,
-                IsolateName(type=IsolateNameType.ISOLATE, value="dummy")
-            ),
-            (
-                None,
-                True,
-                IsolateName(type=IsolateNameType.ISOLATE, value="dummy")
-            ),
-        ]
-    )
-    def test_ignore_name_override_ok(
-        self, precached_repo: Repo, expected_name: IsolateName | None, ignore_name: bool, isolate_name: IsolateName | None):
+    def test_name_override_ok(self, precached_repo: Repo):
         """Test that ignore_name flag works as planned."""
         isolate_1_accessions = ["DQ178610", "DQ178611"]
         isolate_2_accessions = ["DQ178613", "DQ178614"]

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -3,7 +3,7 @@ import subprocess
 from ref_builder.repo import Repo
 from ref_builder.otu.create import create_otu
 from ref_builder.otu.update import (
-    add_isolate,
+    add_genbank_isolate,
     promote_otu_accessions,
     set_representative_isolate,
 )
@@ -68,8 +68,6 @@ class TestUpdateRepresentativeIsolateCommand:
 
         otu_before = scratch_repo.get_otu_by_taxid(taxid)
 
-        repr_isolate_name_before = otu_before.get_isolate(otu_before.repr_isolate).name
-
         repr_isolate_name_after = None
 
         for isolate_id in otu_before.isolate_ids:
@@ -108,7 +106,7 @@ class TestPromoteAccessions:
             ["MF062136", "MF062137", "MF062138"],
             acronym=""
         )
-        isolate = add_isolate(empty_repo, otu, ["MF062125", "MF062126", "MF062127"])
+        isolate = add_genbank_isolate(empty_repo, otu, ["MF062125", "MF062126", "MF062127"])
 
         otu_before = empty_repo.get_otu(otu.id)
 
@@ -166,4 +164,4 @@ class TestPromoteAccessions:
 
         assert otu_after.repr_isolate == otu_before.repr_isolate
 
-        assert otu_after.accessions == {"NC_055390", "NC_055391", "NC_055392",}
+        assert otu_after.accessions == {"NC_055390", "NC_055391", "NC_055392"}


### PR DESCRIPTION
* split `add_isolate()` into `add_genbank_isolate()`, `add_unnamed_isolate()`, `add_and_name_isolate()`
* add `otu.update._create_fetch_list()` utility function
* add `--unnamed` flag to `add-isolate`
* add `--name ISOLATE_TYPE ISOLATE_NAME` option, defaults to `(None, None)`