### PR TITLE
ECO-89: create `LinkSequence` event

### DIFF
--- a/ref_builder/events.py
+++ b/ref_builder/events.py
@@ -158,6 +158,17 @@ class DeleteSequence(Event):
     query: SequenceQuery
 
 
+class LinkSequenceData(EventData):
+    """The data for the linking of an existing sequence to a new isolate."""
+    original_query: SequenceQuery
+
+
+class LinkSequence(Event):
+    """A sequence link event. Links an existing sequence to an isolate."""
+    data: LinkSequenceData
+    query: SequenceQuery
+
+
 class ExcludeAccessionData(EventData):
     """The data for the exclusion of an accession."""
 


### PR DESCRIPTION
Allows the linking of an already created sequence to another sequence. `LinkSequenceData` stores the original `SequenceQuery`.

If this solution doesn't seem quite right, we can brainstorm some different approaches to prototype.