### PR TITLE
ci: drop commitlint and add ruff format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,8 @@ jobs:
   release:
     if: github.event_name == 'push'
     needs:
-      - commitlint
-      - test
       - ruff-format
+      - test
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,22 @@ on:
     branches: [main]
 
 jobs:
-  commitlint:
+  ruff-format:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          fetch-depth: 0
-      - name: Commitlint
-        uses: wagoid/commitlint-github-action@v5
+          python-version: "3.12"
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+      - name: Install packages
+        run: poetry install
+      - name: Run Ruff
+        run: poetry run ruff format --check
+
   test:
     runs-on: ubuntu-22.04
     steps:
@@ -63,6 +70,7 @@ jobs:
     needs:
       - commitlint
       - test
+      - ruff-format
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["ANN101", "D205", "EM101", "EM102", "FBT001", "FBT003", "PTH123", "TRY003"]
+ignore = ["ANN101", "COM812", "D203", "D205", "D213", "EM101", "EM102", "FBT001", "FBT003", "ISC001", "PTH123", "TRY003"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/**" = ["ANN201", "ANN202", "D205", "PLR2004", "S101", "S106"]
 
 # Don't require imperative mood for test fixtures.


### PR DESCRIPTION
* Stop running `commitlint`. This is ignored and PRs are rebased in practice.
* Run `ruff format --check` to ensure only correctly formatted code is merged.
