### PR TITLE
Update CLI module

### DIFF
--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -82,22 +82,20 @@ def otu() -> None:
     required=True,
 )
 @click.option("--acronym", type=str, default="")
-@click.option("--autofill/--no-fill", default=False)
 @ignore_cache_option
 @path_option
 def otu_create(
+    accessions_: list[str],
+    acronym: str,
     ignore_cache: bool,
     path: Path,
     taxid: int,
-    accessions_: list[str],
-    autofill: bool,
-    acronym: str,
 ) -> None:
     """Create a new OTU for the given Taxonomy ID and accessions."""
     repo = Repo(path)
 
     try:
-        new_otu = create_otu(
+        create_otu(
             repo,
             taxid,
             accessions_,
@@ -108,14 +106,11 @@ def otu_create(
         click.echo(e, err=True)
         sys.exit(1)
 
-    if autofill:
-        auto_update_otu(repo, new_otu, ignore_cache=ignore_cache)
-
 
 @otu.command(name="get")
 @click.argument("IDENTIFIER", type=str)
 @path_option
-def otu_get(identifier: str, path: Path) -> int:
+def otu_get(identifier: str, path: Path) -> None:
     """Get an OTU by its Taxonomy ID."""
     try:
         identifier = int(identifier)
@@ -124,12 +119,10 @@ def otu_get(identifier: str, path: Path) -> int:
         otu_ = Repo(path).get_otu(UUID(identifier))
 
     if otu_ is None:
-        click.echo("No OTU found.", err=True)
-        return 1
+        click.echo("OTU not found.", err=True)
+        sys.exit(1)
 
     print_otu(otu_)
-
-    return 0
 
 
 @otu.command(name="list")

--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -14,7 +14,7 @@ from ref_builder.legacy.utils import iter_legacy_otus
 from ref_builder.legacy.validate import validate_legacy_repo
 from ref_builder.logs import configure_logger
 from ref_builder.ncbi.client import NCBIClient
-from ref_builder.options import debug_option, ignore_cache_option, path_option
+from ref_builder.options import ignore_cache_option, path_option
 from ref_builder.otu.create import create_otu
 from ref_builder.otu.update import (
     add_and_name_isolate,
@@ -31,8 +31,10 @@ from ref_builder.utils import DataType, IsolateName, IsolateNameType, format_jso
 
 
 @click.group()
-def entry() -> None:
+@click.option("--debug", is_flag=True, help="Show debug logs")
+def entry(debug: bool) -> None:
     """Build and maintain reference sets of pathogen genome sequences."""
+    configure_logger(debug)
 
 
 @entry.command()
@@ -82,10 +84,8 @@ def otu() -> None:
 @click.option("--acronym", type=str, default="")
 @click.option("--autofill/--no-fill", default=False)
 @ignore_cache_option
-@debug_option
 @path_option
 def otu_create(
-    debug: bool,
     ignore_cache: bool,
     path: Path,
     taxid: int,
@@ -94,8 +94,6 @@ def otu_create(
     acronym: str,
 ) -> None:
     """Create a new OTU for the given Taxonomy ID and accessions."""
-    configure_logger(debug)
-
     repo = Repo(path)
 
     try:
@@ -165,13 +163,10 @@ def update(ctx, path: Path, taxid: int):
 
 
 @update.command(name="automatic")
-@debug_option
 @ignore_cache_option
 @click.pass_context
-def otu_autoupdate(ctx, debug: bool, ignore_cache: bool) -> None:
+def otu_autoupdate(ctx, ignore_cache: bool) -> None:
     """Automatically update an OTU with the latest data from NCBI."""
-    configure_logger(debug)
-
     taxid = ctx.obj["TAXID"]
 
     repo = ctx.obj["REPO"]
@@ -187,17 +182,13 @@ def otu_autoupdate(ctx, debug: bool, ignore_cache: bool) -> None:
 
 
 @update.command(name="promote")
-@debug_option
 @ignore_cache_option
 @click.pass_context
 def otu_promote_accessions(
     ctx,
-    debug: bool = False,
     ignore_cache: bool = False,
 ):
     """Promote all RefSeq accessions within this OTU."""
-    configure_logger(debug)
-
     taxid = ctx.obj["TAXID"]
 
     repo = ctx.obj["REPO"]
@@ -227,19 +218,15 @@ def otu_promote_accessions(
     help='an overriding name for the isolate, e.g. "isolate ARWV1"',
 )
 @ignore_cache_option
-@debug_option
 @click.pass_context
 def isolate_create(
     ctx,
-    debug: bool,
     ignore_cache: bool,
     accessions_: list[str],
     unnamed: bool,
     name: tuple[IsolateNameType, str] | None,
 ) -> None:
     """Create a new isolate using the given accessions."""
-    configure_logger(debug)
-
     repo = ctx.obj["REPO"]
 
     taxid = ctx.obj["TAXID"]
@@ -255,7 +242,6 @@ def isolate_create(
             otu_,
             accessions_,
             ignore_cache=ignore_cache,
-            ignore_name=unnamed,
         )
 
     if name is not None:
@@ -302,16 +288,12 @@ def isolate_create(
     type=str,
     required=True,
 )
-@debug_option
 @click.pass_context
 def accession_exclude(
     ctx,
-    debug: bool,
     accessions_: list[str],
 ) -> None:
     """Exclude the given accessions from this OTU."""
-    configure_logger(debug)
-
     repo = ctx.obj["REPO"]
 
     taxid = ctx.obj["TAXID"]
@@ -326,16 +308,12 @@ def accession_exclude(
 
 @update.command(name="default")
 @click.argument("ISOLATE_KEY", type=str)
-@debug_option
 @click.pass_context
 def otu_set_representative_isolate(
     ctx,
-    debug: bool,
     isolate_key: str,
 ):
     """Update the OTU with a new representative isolate."""
-    configure_logger(debug)
-
     taxid = ctx.obj["TAXID"]
 
     repo = ctx.obj["REPO"]
@@ -440,7 +418,6 @@ def reformat(path: Path) -> None:
 
 
 @legacy.command()
-@debug_option
 @click.option(
     "--fix",
     is_flag=True,
@@ -462,10 +439,8 @@ def reformat(path: Path) -> None:
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="the path to a legacy reference directory",
 )
-def validate(debug: bool, fix: bool, limit: int, no_ok: bool, path: Path) -> None:
+def validate(fix: bool, limit: int, no_ok: bool, path: Path) -> None:
     """Validate a legacy reference repository."""
-    configure_logger(debug)
-
     validate_legacy_repo(fix, limit, no_ok, path)
 
 

--- a/ref_builder/cli.py
+++ b/ref_builder/cli.py
@@ -15,7 +15,11 @@ from ref_builder.legacy.utils import iter_legacy_otus
 from ref_builder.legacy.validate import validate_legacy_repo
 from ref_builder.logs import configure_logger
 from ref_builder.ncbi.client import NCBIClient
-from ref_builder.options import ignore_cache_option, path_option
+from ref_builder.options import (
+    ignore_cache_option,
+    legacy_repo_path_option,
+    path_option,
+)
 from ref_builder.otu.create import create_otu
 from ref_builder.otu.update import (
     add_and_name_isolate,
@@ -30,6 +34,9 @@ from ref_builder.otu.utils import RefSeqConflictError
 from ref_builder.repo import Repo
 from ref_builder.utils import DataType, IsolateName, IsolateNameType, format_json
 
+PRECACHE_BUFFER_SIZE = 450
+"""The number of Genbank records to fetch in a single request when pre-caching."""
+
 
 @click.group()
 @click.option("--debug", is_flag=True, help="Show debug logs")
@@ -41,30 +48,35 @@ def entry(debug: bool) -> None:
 @entry.command()
 @click.option(
     "--data-type",
-    help="the type of data the reference contains (eg. genome)",
+    help="The type of data the reference will contain (eg. genome)",
     required=True,
     type=click.Choice(DataType),
 )
 @click.option(
     "--name",
-    help="the type of data the reference contains (eg. genome)",
+    help="A name for the reference",
     required=True,
     type=str,
 )
 @click.option(
     "--organism",
     default="",
-    help="the organism the reference is for (eg. virus)",
+    help="The organism the reference is for (eg. virus)",
     type=str,
 )
 @click.option(
     "--path",
     default=".",
-    help="the path to initialize the repository at",
+    help="The path to initialize the repository at",
     type=click.Path(path_type=Path),
 )
 def init(data_type: DataType, name: str, organism: str, path: Path) -> None:
-    """Create a new event-sourced repo."""
+    """Create a new reference repository.
+
+    If a path is not provided, the repository will be created in the current directory.
+
+    Repositories cannot be created in non-empty directories.
+    """
     Repo.new(data_type, name, path, organism)
 
 
@@ -92,7 +104,11 @@ def otu_create(
     path: Path,
     taxid: int,
 ) -> None:
-    """Create a new OTU for the given Taxonomy ID and accessions."""
+    """Create a new OTU.
+
+    OTUs are created from a list of accessions and a taxonomy ID. The associated Genbank
+    records are fetched and used to create the first isolate and a plan.
+    """
     repo = Repo(path)
 
     try:
@@ -112,7 +128,7 @@ def otu_create(
 @click.argument("IDENTIFIER", type=str)
 @path_option
 def otu_get(identifier: str, path: Path) -> None:
-    """Get an OTU by its Taxonomy ID."""
+    """Get an OTU by its unique ID or taxonomy ID."""
     try:
         identifier = int(identifier)
         otu_ = Repo(path).get_otu_by_taxid(identifier)
@@ -346,29 +362,19 @@ def legacy() -> None:
     type=str,
 )
 @click.option(
-    "--path",
-    help="the path for the legacy reference repository",
-    required=True,
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-)
-@click.option(
     "--target-path",
     help="the path for the new converted repository",
     required=True,
     type=click.Path(exists=False, file_okay=False, path_type=Path),
 )
+@legacy_repo_path_option
 def convert(name: str, path: Path, target_path: Path) -> None:
     """Convert a legacy reference repository to a new event-sourced repository."""
     convert_legacy_repo(name, path, target_path)
 
 
 @legacy.command()
-@click.option(
-    "--path",
-    help="the name to the legacy reference repository",
-    required=True,
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-)
+@legacy_repo_path_option
 def precache(path: Path) -> None:
     """Pre-cache all accessions in a legacy reference repository."""
     ncbi = NCBIClient(False)
@@ -380,7 +386,7 @@ def precache(path: Path) -> None:
             for sequence in isolate["sequences"]:
                 buffer.append(sequence["accession"])
 
-                if len(buffer) > 450:
+                if len(buffer) > PRECACHE_BUFFER_SIZE:
                     ncbi.fetch_genbank_records(buffer)
                     buffer = []
 
@@ -389,12 +395,7 @@ def precache(path: Path) -> None:
 
 
 @legacy.command(name="format")
-@click.option(
-    "--path",
-    help="the name to the legacy reference repository",
-    required=True,
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-)
+@legacy_repo_path_option
 def reformat(path: Path) -> None:
     """Format a legacy reference repository.
 
@@ -411,24 +412,19 @@ def reformat(path: Path) -> None:
 @click.option(
     "--fix",
     is_flag=True,
-    help="attempt to fix errors in-place",
+    help="Attempt to fix errors in-place",
 )
 @click.option(
     "--limit",
     default=0,
-    help="exit if this many otus have errors",
+    help="Exit if this many OTUs have errors",
 )
 @click.option(
     "--no-ok",
     is_flag=True,
-    help="don't print anything if an otu is valid",
+    help="Don't print anything if an otu is valid",
 )
-@click.option(
-    "--path",
-    required=True,
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-    help="the path to a legacy reference directory",
-)
+@legacy_repo_path_option
 def validate(fix: bool, limit: int, no_ok: bool, path: Path) -> None:
     """Validate a legacy reference repository."""
     validate_legacy_repo(fix, limit, no_ok, path)
@@ -439,29 +435,23 @@ def validate(fix: bool, limit: int, no_ok: bool, path: Path) -> None:
     "-i",
     "--indent",
     is_flag=True,
-    help="auto-indent the output JSON file",
+    help="Indent the output JSON file",
 )
 @click.option(
     "-V",
     "--version",
     default="",
     type=str,
-    help="a version string to include in the reference.json file",
+    help="A version string to include in the output file",
 )
 @click.option(
     "-o",
-    "--output-path",
+    "--target-path",
     required=True,
     type=click.Path(exists=False, file_okay=True, path_type=Path),
-    help="the path to write the reference.json file to",
+    help="The path to write the reference.json file to",
 )
-@click.option(
-    "-p",
-    "--path",
-    required=True,
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-    help="the path to the reference repository",
-)
-def build(output_path: Path, path: Path, indent: bool, version: str) -> None:
-    """Build a Virtool reference.json file from a reference repository."""
-    build_json(indent, output_path, path, version)
+@path_option
+def build(indent: bool, path: Path, target_path: Path, version: str) -> None:
+    """Build a Virtool reference.json file from the reference repository."""
+    build_json(indent, target_path, path, version)

--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -1,8 +1,9 @@
-from collections.abc import Iterable
+from collections.abc import Iterator
 
 import rich.console
 from rich.table import Table
 
+from ref_builder.models import OTUMinimal
 from ref_builder.resources import RepoOTU
 
 
@@ -71,7 +72,7 @@ def print_otu(otu: RepoOTU) -> None:
     for isolate in otu.isolates:
         console.line()
         console.print(str(isolate.name)) if isolate.name is not None else console.print(
-            "[UNNAMED]"
+            "[UNNAMED]",
         )
         console.line()
 
@@ -93,7 +94,7 @@ def print_otu(otu: RepoOTU) -> None:
         console.print(isolate_table)
 
 
-def print_otu_list(otus: Iterable[RepoOTU]) -> None:
+def print_otu_list(otus: Iterator[OTUMinimal]) -> None:
     """Print a list of OTUs to the console.
 
     :param otus: The OTUs to print.

--- a/ref_builder/options.py
+++ b/ref_builder/options.py
@@ -4,9 +4,6 @@ from pathlib import Path
 
 import click
 
-debug_option = click.option("--debug", is_flag=True, help="Show debug logs")
-"""A click option for enabling debug logging."""
-
 ignore_cache_option = click.option(
     "--ignore-cache",
     is_flag=True,

--- a/ref_builder/options.py
+++ b/ref_builder/options.py
@@ -11,6 +11,16 @@ ignore_cache_option = click.option(
 )
 """A click option for disabling cached results in fetch operations."""
 
+
+legacy_repo_path_option = click.option(
+    "--path",
+    help="The path to the legacy reference repository",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+"""A click option for the path to the legacy reference repository."""
+
+
 path_option = click.option(
     "--path",
     default=".",

--- a/ref_builder/otu/create.py
+++ b/ref_builder/otu/create.py
@@ -47,9 +47,8 @@ def create_otu(
         otu_logger.fatal(f"Could not retrieve {taxid} from NCBI Taxonomy")
         return None
 
-    if not acronym:
-        if taxonomy.other_names.acronym:
-            acronym = taxonomy.other_names.acronym[0]
+    if not acronym and taxonomy.other_names.acronym:
+        acronym = taxonomy.other_names.acronym[0]
 
     records = client.fetch_genbank_records(accessions)
 
@@ -79,7 +78,6 @@ def create_otu(
             schema=schema,
             taxid=taxid,
         )
-
     except ValueError as e:
         otu_logger.fatal(e)
         sys.exit(1)
@@ -91,7 +89,6 @@ def create_otu(
     )
 
     otu.add_isolate(isolate)
-
     otu.repr_isolate = repo.set_repr_isolate(otu_id=otu.id, isolate_id=isolate.id)
 
     for record in records:
@@ -106,7 +103,7 @@ def create_otu(
         )
 
         if record.refseq:
-            refseq_status, old_accession = parse_refseq_comment(record.comment)
+            _, old_accession = parse_refseq_comment(record.comment)
             repo.exclude_accession(
                 otu.id,
                 old_accession,

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -39,28 +39,6 @@
     'EF546813',
   })
 # ---
-# name: TestCreateOTUCommands.test_autofill_ok
-  dict({
-    'molecule': dict({
-      'strandedness': 'double',
-      'topology': 'circular',
-      'type': 'DNA',
-    }),
-    'multipartite': True,
-    'segments': list([
-      dict({
-        'length': 2575,
-        'name': 'DNA A',
-        'required': True,
-      }),
-      dict({
-        'length': 2494,
-        'name': 'DNA B',
-        'required': True,
-      }),
-    ]),
-  })
-# ---
 # name: TestCreateOTUCommands.test_ok[1278205-accessions0]
   dict({
     'acronym': '',

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -8,10 +8,10 @@ from syrupy.filters import props
 
 from ref_builder.otu.create import create_otu
 from ref_builder.otu.update import (
-    auto_update_otu,
+    add_and_name_isolate,
     add_genbank_isolate,
     add_unnamed_isolate,
-    add_and_name_isolate,
+    auto_update_otu,
     delete_isolate_from_otu,
     replace_sequence_in_otu,
     update_isolate_from_accessions,
@@ -27,17 +27,19 @@ def run_create_otu_command(
     taxid: int,
     accessions: list,
     acronym: str = "",
-    autofill: bool = False,
 ):
-    autofill_option = ["--autofill"] if autofill else []
-
     subprocess.run(
-        ["ref-builder", "otu", "create"]
-        + [str(taxid)]
-        + accessions
-        + ["--path", str(path)]
-        + ["--acronym", acronym]
-        + autofill_option,
+        [
+            "ref-builder",
+            "otu",
+            "create",
+            str(taxid),
+            *accessions,
+            "--path",
+            str(path),
+            "--acronym",
+            acronym,
+        ],
         check=False,
     )
 
@@ -63,7 +65,9 @@ class TestCreateOTU:
             "",
         )
 
-        assert otu.model_dump() == snapshot(exclude=props("id", "isolates", "repr_isolate"))
+        assert otu.model_dump() == snapshot(
+            exclude=props("id", "isolates", "repr_isolate"),
+        )
 
         # Ensure only one OTU is present in the repository, and it matches the return
         # value of the creation function.
@@ -102,10 +106,13 @@ class TestCreateOTU:
         assert otu.repr_isolate is not None
 
     def test_otu_create_refseq_autoexclude(
-        self, precached_repo: Repo, snapshot: SnapshotAssertion
+        self,
+        precached_repo: Repo,
+        snapshot: SnapshotAssertion,
     ):
         """Test that the superceded accessions included in RefSeq metadata
-        are automatically added to the OTU's excluded accessions list."""
+        are automatically added to the OTU's excluded accessions list.
+        """
         otu = create_otu(
             precached_repo,
             3158377,
@@ -116,18 +123,21 @@ class TestCreateOTU:
                 "NC_010317",
                 "NC_010318",
                 "NC_010319",
-            ], ""
+            ],
+            "",
         )
 
         assert (
-            otu.excluded_accessions == {
+            otu.excluded_accessions
+            == {
                 "EF546808",
                 "EF546809",
                 "EF546810",
                 "EF546811",
                 "EF546812",
                 "EF546813",
-            } == snapshot
+            }
+            == snapshot
         )
 
     def test_otu_create_with_acronym_auto(self, precached_repo: Repo):
@@ -174,51 +184,30 @@ class TestCreateOTUCommands:
         assert len(otus) == 1
         otu = otus[0]
 
-        assert otu.model_dump() == snapshot(exclude=props("id", "isolates", "repr_isolate"))
-
-    @pytest.mark.ncbi()
-    def test_autofill_ok(
-        self,
-        precached_repo: Repo,
-        snapshot: SnapshotAssertion,
-    ):
-        run_create_otu_command(
-            taxid=345184,
-            accessions=["DQ178610", "DQ178611"],
-            path=precached_repo.path,
-            autofill=True,
+        assert otu.model_dump() == snapshot(
+            exclude=props("id", "isolates", "repr_isolate"),
         )
 
-        otus = list(Repo(precached_repo.path).iter_otus())
-
-        assert len(otus) == 1
-        otu = otus[0]
-
-        assert otu.schema.model_dump() == snapshot(exclude=props("id"))
-
-        assert {"DQ178610", "DQ178611"}.intersection(otu.accessions)
-
-    def test_add_acronym_ok(self, precached_repo: Repo):
+    def test_acronym(self, precached_repo: Repo):
         """Test if the --acronym option works as planned."""
         run_create_otu_command(
             taxid=345184,
             accessions=["DQ178610", "DQ178611"],
             path=precached_repo.path,
             acronym="CabLCJV",
-            autofill=True,
         )
 
         otus = list(Repo(precached_repo.path).iter_otus())
 
         assert len(otus) == 1
-        otu = otus[0]
-
-        assert otu.acronym == "CabLCJV"
+        assert otus[0].acronym == "CabLCJV"
 
 
 class TestAddIsolate:
     def test_genbank_ok(self, precached_repo: Repo):
-        """Test that add_genbank_isolate() adds an isolate with a correctly parsed name."""
+        """Test that add_genbank_isolate() adds an isolate with a correctly parsed
+        name.
+        """
         isolate_1_accessions = ["DQ178610", "DQ178611"]
         isolate_2_accessions = ["DQ178613", "DQ178614"]
 
@@ -230,13 +219,18 @@ class TestAddIsolate:
 
         otu_after = precached_repo.get_otu_by_taxid(345184)
 
-        assert otu_after.accessions == set(isolate_1_accessions).union(set(isolate_2_accessions))
+        assert otu_after.accessions == set(isolate_1_accessions).union(
+            set(isolate_2_accessions),
+        )
 
         isolate_after = otu_after.get_isolate(isolate.id)
 
         assert isolate_after.accessions == set(isolate_2_accessions)
 
-        assert isolate_after.name == IsolateName(IsolateNameType.ISOLATE, "Douglas Castle")
+        assert isolate_after.name == IsolateName(
+            IsolateNameType.ISOLATE,
+            "Douglas Castle",
+        )
 
     def test_ignore_name_ok(self, precached_repo: Repo):
         """Test that add_unnamed_isolate() adds the correct isolate with its name set to None."""
@@ -272,7 +266,7 @@ class TestAddIsolate:
             precached_repo,
             otu,
             isolate_2_accessions,
-            isolate_name=IsolateName(type=IsolateNameType.ISOLATE, value="dummy")
+            isolate_name=IsolateName(type=IsolateNameType.ISOLATE, value="dummy"),
         )
 
         otu_after = precached_repo.get_otu_by_taxid(345184)
@@ -281,13 +275,17 @@ class TestAddIsolate:
 
         isolate_after = otu_after.get_isolate(isolate.id)
 
-        assert isolate_after.name == IsolateName(type=IsolateNameType.ISOLATE, value="dummy")
+        assert isolate_after.name == IsolateName(
+            type=IsolateNameType.ISOLATE,
+            value="dummy",
+        )
 
         assert isolate_after.accessions == {"DQ178613", "DQ178614"}
 
     def test_conflict_fail(self, precached_repo: Repo):
         """Test that an isolate cannot be added to an OTU
-        if both its name and its accessions are already contained."""
+        if both its name and its accessions are already contained.
+        """
         taxid = 2164102
         accessions = ["MF062136", "MF062137", "MF062138"]
 
@@ -325,7 +323,9 @@ class TestUpdateOTU:
 
         assert otu_after.isolate_ids.issuperset(otu_before.isolate_ids)
 
-        assert {isolate.name: isolate.accessions for isolate in otu_after.isolates} == snapshot()
+        assert {
+            isolate.name: isolate.accessions for isolate in otu_after.isolates
+        } == snapshot()
 
         assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}
 
@@ -361,10 +361,8 @@ class TestUpdateOTU:
 
         assert (
             otu_before.accessions
-            ==
-            otu_before.get_isolate(otu_before.repr_isolate).accessions
-            ==
-            {"MF062125", "MF062126", "MF062127"}
+            == otu_before.get_isolate(otu_before.repr_isolate).accessions
+            == {"MF062125", "MF062126", "MF062127"}
         )
 
         auto_update_otu(precached_repo, otu_before)
@@ -383,8 +381,7 @@ class TestUpdateOTU:
 
         assert (
             otu_after.get_isolate(otu_before.repr_isolate).accessions
-            !=
-            otu_before.get_isolate(otu_before.repr_isolate).accessions
+            != otu_before.get_isolate(otu_before.repr_isolate).accessions
         )
 
         assert otu_after.id == otu_before.id
@@ -413,19 +410,26 @@ class TestUpdateOTU:
 
 
 @pytest.mark.parametrize(
-        "taxid, original_accessions, refseq_accessions",
-        [
-            (1169032, ["AB017503"], ["NC_003355"]),
-            (345184, ["DQ178608", "DQ178609"], ["NC_038792", "NC_038793"])
-        ]
-    )
+    "taxid, original_accessions, refseq_accessions",
+    [
+        (1169032, ["AB017503"], ["NC_003355"]),
+        (345184, ["DQ178608", "DQ178609"], ["NC_038792", "NC_038793"]),
+    ],
+)
 class TestReplaceIsolateSequences:
     def test_manual_replace_ok(
-        self, empty_repo, taxid, original_accessions, refseq_accessions
+        self,
+        empty_repo,
+        taxid,
+        original_accessions,
+        refseq_accessions,
     ):
         """Test that a requested replacement occurs as expected."""
         create_otu(
-            empty_repo, taxid, accessions=original_accessions, acronym=""
+            empty_repo,
+            taxid,
+            accessions=original_accessions,
+            acronym="",
         )
 
         otu_before = empty_repo.get_otu_by_taxid(taxid)
@@ -434,7 +438,12 @@ class TestReplaceIsolateSequences:
 
         isolate = list(otu_before.isolates)[0]
 
-        update_isolate_from_accessions(empty_repo, otu_before, isolate.name, refseq_accessions)
+        update_isolate_from_accessions(
+            empty_repo,
+            otu_before,
+            isolate.name,
+            refseq_accessions,
+        )
 
         otu_after = empty_repo.get_otu(otu_before.id)
 
@@ -450,9 +459,13 @@ class TestReplaceIsolateSequences:
         refseq_accessions: list[str],
     ):
         """Test that attempting to add an isolate with RefSeq accessions
-        raises RefSeqConflictError"""
+        raises RefSeqConflictError
+        """
         create_otu(
-            empty_repo, taxid, accessions=original_accessions, acronym=""
+            empty_repo,
+            taxid,
+            accessions=original_accessions,
+            acronym="",
         )
 
         otu_before = empty_repo.get_otu_by_taxid(taxid)
@@ -473,7 +486,7 @@ class TestRemoveIsolate:
         otu_before = scratch_repo.get_otu_by_taxid(taxid)
 
         isolate_id = otu_before.get_isolate_id_by_name(
-            IsolateName(type=IsolateNameType.ISOLATE, value="WMoV-6.3")
+            IsolateName(type=IsolateNameType.ISOLATE, value="WMoV-6.3"),
         )
 
         assert type(isolate_id) is UUID
@@ -499,8 +512,10 @@ class TestReplaceSequence:
             acronym="",
         )
 
-        isolate_id, old_sequence_id = otu_before.get_sequence_id_hierarchy_from_accession(
-            "MK431779"
+        isolate_id, old_sequence_id = (
+            otu_before.get_sequence_id_hierarchy_from_accession(
+                "MK431779",
+            )
         )
 
         assert type(old_sequence_id) is UUID
@@ -509,7 +524,7 @@ class TestReplaceSequence:
             repo=precached_repo,
             otu=otu_before,
             new_accession="NC_003355",
-            replaced_accession="MK431779"
+            replaced_accession="MK431779",
         )
 
         assert type(sequence) is RepoSequence


### PR DESCRIPTION
The main drive for this PR is resolving Ruff format and linter warnings.

* Move `--debug` option and logging configuration to root command.
* Remove `--autofill` option from `otu create`. This should be done by a subsequent `otu update automatic`.
* Fixing typing issues.
* Update command docs.
* Extract legacy repo path option to `options.py`.

