### PR TITLE
ECO-92: add isolate plan modification commands

### DIFF
--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -29,6 +29,7 @@ from ref_builder.otu.update import (
     add_unnamed_isolate,
     auto_update_otu,
     exclude_accessions_from_otu,
+    replace_isolate_plan,
     promote_otu_accessions,
     set_representative_isolate,
 )
@@ -358,10 +359,39 @@ def otu_set_representative_isolate(
 
     set_representative_isolate(repo, otu_, isolate_id)
 
-@update.group(invoke_without_command=True)
+@update.group()
 @click.pass_context
 def plan(ctx: Context) -> None:
     """Add to and replace isolate plans for this OTU."""
+
+
+@plan.command(name="replace")
+@click.argument(
+    "accessions_",
+    metavar="ACCESSIONS",
+    nargs=-1,
+    type=str,
+    required=True,
+)
+@click.pass_context
+@ignore_cache_option
+def plan_replace(
+    ctx: Context, accessions_: list[str], ignore_cache: bool,
+) -> None:
+    repo = ctx.obj["REPO"]
+    taxid = ctx.obj["TAXID"]
+
+    otu_ = repo.get_otu_by_taxid(taxid)
+    if otu_ is None:
+        click.echo(f"OTU {taxid} not found.", err=True)
+        sys.exit(1)
+
+    replace_isolate_plan(
+        repo,
+        otu_,
+        accessions=accessions_,
+        ignore_cache=ignore_cache
+    )
 
 
 @plan.command(name="expand")

--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -392,7 +392,7 @@ def plan_replace(
     replace_isolate_plan(repo, otu_, accessions=accessions_, ignore_cache=ignore_cache)
 
 
-@plan.command(name="expand")
+@plan.command(name="extend")
 @click.argument(
     "accessions_",
     metavar="ACCESSIONS",
@@ -402,14 +402,14 @@ def plan_replace(
 )
 @click.option(
     "--rule",
-    default=SegmentRule.REQUIRED,
+    default=SegmentRule.RECOMMENDED,
     type=click.Choice(
-        [SegmentRule.REQUIRED, SegmentRule.REQUIRED, SegmentRule.OPTIONAL]
+        [SegmentRule.RECOMMENDED, SegmentRule.OPTIONAL]
     ),
 )
 @click.pass_context
 @ignore_cache_option
-def plan_expand_segment_list(
+def plan_extend_segment_list(
     ctx: Context,
     accessions_: list[str],
     rule: SegmentRule,

--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -364,6 +364,7 @@ def otu_set_representative_isolate(
 def plan(ctx: Context) -> None:
     """Add to and replace isolate plans for this OTU."""
 
+
 @plan.command(name="extend")
 @click.argument(
     "accessions_",
@@ -399,7 +400,7 @@ def plan_extend_segment_list(
         otu_,
         rule=SegmentRule.OPTIONAL if optional else SegmentRule.RECOMMENDED,
         accessions=accessions_,
-        ignore_cache=ignore_cache
+        ignore_cache=ignore_cache,
     )
 
 

--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -365,33 +365,6 @@ def otu_set_representative_isolate(
 def plan(ctx: Context) -> None:
     """Add to and replace isolate plans for this OTU."""
 
-
-@plan.command(name="replace")
-@click.argument(
-    "accessions_",
-    metavar="ACCESSIONS",
-    nargs=-1,
-    type=str,
-    required=True,
-)
-@click.pass_context
-@ignore_cache_option
-def plan_replace(
-    ctx: Context,
-    accessions_: list[str],
-    ignore_cache: bool,
-) -> None:
-    repo = ctx.obj["REPO"]
-    taxid = ctx.obj["TAXID"]
-
-    otu_ = repo.get_otu_by_taxid(taxid)
-    if otu_ is None:
-        click.echo(f"OTU {taxid} not found.", err=True)
-        sys.exit(1)
-
-    replace_isolate_plan(repo, otu_, accessions=accessions_, ignore_cache=ignore_cache)
-
-
 @plan.command(name="extend")
 @click.argument(
     "accessions_",
@@ -401,20 +374,19 @@ def plan_replace(
     required=True,
 )
 @click.option(
-    "--rule",
-    default=SegmentRule.RECOMMENDED,
-    type=click.Choice(
-        [SegmentRule.RECOMMENDED, SegmentRule.OPTIONAL]
-    ),
+    "--optional",
+    is_flag=True,
+    help="Set additional segments as fully optional",
 )
 @click.pass_context
 @ignore_cache_option
 def plan_extend_segment_list(
     ctx: Context,
     accessions_: list[str],
-    rule: SegmentRule,
+    optional: bool,
     ignore_cache: bool,
 ) -> None:
+    """Add recommended or optional segments to the OTU plan."""
     repo = ctx.obj["REPO"]
     taxid = ctx.obj["TAXID"]
 
@@ -424,7 +396,11 @@ def plan_extend_segment_list(
         sys.exit(1)
 
     add_segments_to_plan(
-        repo, otu_, rule=rule, accessions=accessions_, ignore_cache=ignore_cache
+        repo,
+        otu_,
+        rule=SegmentRule.OPTIONAL if optional else SegmentRule.RECOMMENDED,
+        accessions=accessions_,
+        ignore_cache=ignore_cache
     )
 
 

--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -359,6 +359,7 @@ def otu_set_representative_isolate(
 
     set_representative_isolate(repo, otu_, isolate_id)
 
+
 @update.group()
 @click.pass_context
 def plan(ctx: Context) -> None:
@@ -376,7 +377,9 @@ def plan(ctx: Context) -> None:
 @click.pass_context
 @ignore_cache_option
 def plan_replace(
-    ctx: Context, accessions_: list[str], ignore_cache: bool,
+    ctx: Context,
+    accessions_: list[str],
+    ignore_cache: bool,
 ) -> None:
     repo = ctx.obj["REPO"]
     taxid = ctx.obj["TAXID"]
@@ -386,12 +389,7 @@ def plan_replace(
         click.echo(f"OTU {taxid} not found.", err=True)
         sys.exit(1)
 
-    replace_isolate_plan(
-        repo,
-        otu_,
-        accessions=accessions_,
-        ignore_cache=ignore_cache
-    )
+    replace_isolate_plan(repo, otu_, accessions=accessions_, ignore_cache=ignore_cache)
 
 
 @plan.command(name="expand")
@@ -403,16 +401,19 @@ def plan_replace(
     required=True,
 )
 @click.option(
-    '--rule',
+    "--rule",
     default=SegmentRule.REQUIRED,
     type=click.Choice(
         [SegmentRule.REQUIRED, SegmentRule.REQUIRED, SegmentRule.OPTIONAL]
-    )
+    ),
 )
 @click.pass_context
 @ignore_cache_option
 def plan_expand_segment_list(
-    ctx: Context, accessions_: list[str], rule: SegmentRule, ignore_cache: bool,
+    ctx: Context,
+    accessions_: list[str],
+    rule: SegmentRule,
+    ignore_cache: bool,
 ) -> None:
     repo = ctx.obj["REPO"]
     taxid = ctx.obj["TAXID"]
@@ -423,11 +424,7 @@ def plan_expand_segment_list(
         sys.exit(1)
 
     add_segments_to_plan(
-        repo,
-        otu_,
-        rule=rule,
-        accessions=accessions_,
-        ignore_cache=ignore_cache
+        repo, otu_, rule=rule, accessions=accessions_, ignore_cache=ignore_cache
     )
 
 

--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -395,13 +395,16 @@ def plan_extend_segment_list(
         click.echo(f"OTU {taxid} not found.", err=True)
         sys.exit(1)
 
-    add_segments_to_plan(
-        repo,
-        otu_,
-        rule=SegmentRule.OPTIONAL if optional else SegmentRule.RECOMMENDED,
-        accessions=accessions_,
-        ignore_cache=ignore_cache,
-    )
+    try:
+        add_segments_to_plan(
+            repo,
+            otu_,
+            rule=SegmentRule.OPTIONAL if optional else SegmentRule.RECOMMENDED,
+            accessions=accessions_,
+            ignore_cache=ignore_cache,
+        )
+    except ValueError as e:
+        click.echo(e, err=True)
 
 
 @entry.group()

--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -33,6 +33,7 @@ from ref_builder.otu.update import (
     set_representative_isolate,
 )
 from ref_builder.otu.utils import RefSeqConflictError
+from ref_builder.plan import SegmentRule
 from ref_builder.repo import Repo
 from ref_builder.utils import DataType, IsolateName, IsolateNameType, format_json
 
@@ -373,13 +374,15 @@ def plan(ctx: Context) -> None:
 )
 @click.option(
     '--rule',
-    default="required",
-    type=click.Choice(["required", 'recommended', 'optional'])
+    default=SegmentRule.REQUIRED,
+    type=click.Choice(
+        [SegmentRule.REQUIRED, SegmentRule.REQUIRED, SegmentRule.OPTIONAL]
+    )
 )
 @click.pass_context
 @ignore_cache_option
 def plan_expand_segment_list(
-    ctx: Context, accessions_: list[str], rule: str, ignore_cache: bool,
+    ctx: Context, accessions_: list[str], rule: SegmentRule, ignore_cache: bool,
 ) -> None:
     repo = ctx.obj["REPO"]
     taxid = ctx.obj["TAXID"]
@@ -389,7 +392,13 @@ def plan_expand_segment_list(
         click.echo(f"OTU {taxid} not found.", err=True)
         sys.exit(1)
 
-    add_segments_to_plan(repo, otu_, accessions_, rule, ignore_cache)
+    add_segments_to_plan(
+        repo,
+        otu_,
+        rule=rule,
+        accessions=accessions_,
+        ignore_cache=ignore_cache
+    )
 
 
 @entry.group()

--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -29,7 +29,6 @@ from ref_builder.otu.update import (
     add_unnamed_isolate,
     auto_update_otu,
     exclude_accessions_from_otu,
-    replace_isolate_plan,
     promote_otu_accessions,
     set_representative_isolate,
 )

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -232,6 +232,23 @@ def create_isolate_from_records(
     return isolate
 
 
+def set_isolate_plan(
+    repo: Repo,
+    otu: RepoOTU,
+    plan: MonopartitePlan | MultipartitePlan,
+) -> MonopartitePlan | MultipartitePlan | None:
+    """Sets an OTU's isolate plan to a new plan."""
+    otu_logger = logger.bind(name=otu.name, taxid=otu.taxid, plan=plan.model_dump())
+
+    try:
+        repo.set_isolate_plan(otu.id, plan)
+    except ValueError as e:
+        otu_logger.error(e)
+        return None
+
+    return repo.get_otu(otu.id).plan
+
+
 def set_representative_isolate(
     repo: Repo,
     otu: RepoOTU,

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -256,10 +256,17 @@ def add_segments_to_plan(
     rule: SegmentRule,
     accessions: list[str],
     ignore_cache: bool = False,
-):
+) -> MonopartitePlan | MultipartitePlan | None:
     expand_logger = logger.bind(
         name=otu.name, taxid=otu.taxid, accessions=accessions, rule=rule
     )
+
+    if type(otu.plan) is MonopartitePlan:
+        expand_logger.error(
+            "Cannot add segments to a monopartite plan.",
+            current_plan=otu.plan.model_dump(),
+        )
+        return otu.plan
 
     client = NCBIClient(ignore_cache)
 

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -16,7 +16,7 @@ from ref_builder.plan import (
     MonopartitePlan,
     MultipartitePlan,
     SegmentName,
-    SegmentPlan,
+    Segment,
     SegmentRule,
 )
 from ref_builder.repo import Repo
@@ -337,7 +337,7 @@ def resize_monopartite_plan(
 
     new_plan = MultipartitePlan.new(
         segments=[
-            SegmentPlan(
+            Segment(
                 id=uuid4(),
                 length=otu.plan.length,
                 name=name,

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -9,7 +9,6 @@ from ref_builder.otu.utils import (
     DeleteRationale,
     RefSeqConflictError,
     create_segments_from_records,
-    create_isolate_plan_from_records,
     group_genbank_records_by_isolate,
     parse_refseq_comment,
 )
@@ -247,42 +246,6 @@ def set_isolate_plan(
     except ValueError as e:
         otu_logger.error(e)
         return None
-
-    return repo.get_otu(otu.id).plan
-
-
-def replace_isolate_plan(
-    repo: Repo,
-    otu: RepoOTU,
-    accessions: list[str],
-    ignore_cache: bool = False,
-) -> MonopartitePlan | MultipartitePlan | None:
-    """Create a new isolate plan based on the given accessions
-    and replace the former plan."""
-    replace_logger = logger.bind(name=otu.name, taxid=otu.taxid, accessions=accessions)
-
-    replace_logger.info(
-        "Replacing isolate plan using new accessions",
-        current_plan=otu.plan.model_dump(),
-    )
-
-    client = NCBIClient(ignore_cache)
-    records = client.fetch_genbank_records(accessions)
-    if not records:
-        replace_logger.warning("Could not fetch records.")
-        return None
-
-    new_plan = create_isolate_plan_from_records(records)
-    if new_plan is None:
-        replace_logger.error("Isolate plan could not be created.")
-        return None
-
-    repo.set_isolate_plan(otu.id, new_plan)
-
-    replace_logger.info(
-        f"New plan created: {[str(segment.name) for segment in new_plan.segments]}.",
-        expanded_plan=new_plan.model_dump(),
-    )
 
     return repo.get_otu(otu.id).plan
 

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -288,8 +288,7 @@ def add_segments_to_plan(
         expand_logger.warning("No segments can be added.")
         return None
 
-    new_plan = MultipartitePlan(
-        id=uuid4(),
+    new_plan = MultipartitePlan.new(
         segments=otu.plan.segments + new_segments,
     )
 
@@ -336,8 +335,7 @@ def resize_monopartite_plan(
         expand_logger.warning("No segments can be added.")
         return None
 
-    new_plan = MultipartitePlan(
-        id=uuid4(),
+    new_plan = MultipartitePlan.new(
         segments=[
             SegmentPlan(
                 id=uuid4(),

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -294,12 +294,15 @@ def add_segments_to_plan(
     accessions: list[str],
     ignore_cache: bool = False,
 ):
-    expand_logger = logger.bind(name=otu.name, taxid=otu.taxid, accessions=accessions, rule=rule)
+    expand_logger = logger.bind(
+        name=otu.name, taxid=otu.taxid, accessions=accessions, rule=rule
+    )
 
     client = NCBIClient(ignore_cache)
 
     expand_logger.info(
-        f"Adding {len(accessions)} sequences to plan as {rule} segments", current_plan=otu.plan.model_dump()
+        f"Adding {len(accessions)} sequences to plan as {rule} segments",
+        current_plan=otu.plan.model_dump(),
     )
 
     records = client.fetch_genbank_records(accessions)

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -74,9 +74,7 @@ def create_isolate_plan_from_records(
 ) -> MonopartitePlan | MultipartitePlan | None:
     """Return a plan from a list of records representing an isolate."""
     if len(records) == 1:
-        return MonopartitePlan(
-            plan_type="monopartite", id=uuid4(), length=len(records[0].sequence)
-        )
+        return MonopartitePlan.new(length=len(records[0].sequence))
 
     binned_records = group_genbank_records_by_isolate(records)
     if len(binned_records) > 1:
@@ -87,14 +85,12 @@ def create_isolate_plan_from_records(
         return None
 
     if segments is not None:
-        return MultipartitePlan(id=uuid4(), segments=segments)
+        return MultipartitePlan.new(segments=segments)
 
     segments = create_segments_from_records(records, rule=SegmentRule.REQUIRED)
 
     if segments:
-        return MultipartitePlan(
-            plan_type="multipartite", id=uuid4(), segments=segments
-        )
+        return MultipartitePlan.new(segments=segments)
 
     return None
 

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -10,7 +10,7 @@ from ref_builder.ncbi.models import NCBIGenbank
 from ref_builder.plan import (
     MonopartitePlan,
     MultipartitePlan,
-    SegmentPlan,
+    Segment,
     SegmentRule,
     get_multipartite_segment_name,
 )
@@ -48,7 +48,7 @@ class RefSeqConflictError(ValueError):
 def create_segments_from_records(
     records: list[NCBIGenbank],
     rule: SegmentRule,
-) -> list[SegmentPlan]:
+) -> list[Segment]:
     """Return a list of SegmentPlans."""
     segments = []
 
@@ -57,7 +57,7 @@ def create_segments_from_records(
             raise ValueError("No segment name found for multipartite OTU segment.")
 
         segments.append(
-            SegmentPlan(
+            Segment(
                 id=uuid4(),
                 name=get_multipartite_segment_name(record),
                 required=rule,
@@ -70,7 +70,7 @@ def create_segments_from_records(
 
 def create_isolate_plan_from_records(
     records: list[NCBIGenbank],
-    segments: list[SegmentPlan] | None = None,
+    segments: list[Segment] | None = None,
 ) -> MonopartitePlan | MultipartitePlan | None:
     """Return a plan from a list of records representing an isolate."""
     if len(records) == 1:

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -74,7 +74,9 @@ def create_isolate_plan_from_records(
 ) -> MonopartitePlan | MultipartitePlan | None:
     """Return a plan from a list of records representing an isolate."""
     if len(records) == 1:
-        return MonopartitePlan(id=uuid4(), length=len(records[0].sequence))
+        return MonopartitePlan(
+            plan_type="monopartite", id=uuid4(), length=len(records[0].sequence)
+        )
 
     binned_records = group_genbank_records_by_isolate(records)
     if len(binned_records) > 1:
@@ -90,7 +92,9 @@ def create_isolate_plan_from_records(
     segments = create_segments_from_records(records, rule=SegmentRule.REQUIRED)
 
     if segments:
-        return MultipartitePlan(id=uuid4(), segments=segments)
+        return MultipartitePlan(
+            plan_type="multipartite", id=uuid4(), segments=segments
+        )
 
     return None
 

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -125,9 +125,10 @@ class MultipartitePlan(BaseModel):
         )
 
 
-IsolatePlan = Annotated[
+Plan = Annotated[
     Union[MultipartitePlan, MonopartitePlan], Field(discriminator="plan_type")
 ]
+"""A discriminated union representing both plan types, monopartite and multipartite."""
 
 
 def determine_segment_prefix(moltype: NCBISourceMolType) -> str:

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 from typing import Annotated, Literal, Union
 from uuid import uuid4
 
-from pydantic import UUID4, BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import UUID4, BaseModel, ConfigDict, Field
 from pydantic.dataclasses import dataclass
 
 from ref_builder.ncbi.models import NCBIGenbank, NCBISourceMolType
@@ -126,8 +126,6 @@ class MultipartitePlan(BaseModel):
 
 
 IsolatePlan = Annotated[Union[MultipartitePlan, MonopartitePlan], Field(discriminator="plan_type")]
-
-plan_typer = TypeAdapter(IsolatePlan)
 
 
 def determine_segment_prefix(moltype: NCBISourceMolType) -> str:

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -1,8 +1,8 @@
 import re
 from enum import StrEnum
-from typing import Union
+from typing import Annotated, Literal, Union
 
-from pydantic import UUID4, BaseModel, ConfigDict, TypeAdapter
+from pydantic import UUID4, BaseModel, ConfigDict, Field, TypeAdapter
 from pydantic.dataclasses import dataclass
 
 from ref_builder.ncbi.models import NCBIGenbank, NCBISourceMolType
@@ -67,6 +67,9 @@ class SegmentPlan(SegmentMetadata):
 class MonopartitePlan(BaseModel):
     """Expected properties for an acceptable monopartite isolate."""
 
+    plan_type: Literal["monopartite"]
+    """The plan type identifier."""
+
     id: UUID4
     """The unique ID of the monopartite plan."""
 
@@ -88,6 +91,9 @@ class MonopartitePlan(BaseModel):
 class MultipartitePlan(BaseModel):
     """Expected segments for an acceptable multipartite isolate."""
 
+    plan_type: Literal["multipartite"]
+    """The plan type identifier."""
+
     id: UUID4
     """The unique id number of the multipartite plan"""
 
@@ -99,7 +105,7 @@ class MultipartitePlan(BaseModel):
         return [segment for segment in self.segments if segment.required]
 
 
-IsolatePlan = Union[MultipartitePlan, MonopartitePlan]
+IsolatePlan = Annotated[Union[MultipartitePlan, MonopartitePlan], Field(discriminator="plan_type")]
 
 plan_typer = TypeAdapter(IsolatePlan)
 

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -53,7 +53,7 @@ class SegmentMetadata(BaseModel):
     """The expected length of the sequence"""
 
 
-class SegmentPlan(SegmentMetadata):
+class Segment(SegmentMetadata):
     """A segment in a multipartite plan."""
 
     model_config = ConfigDict(use_enum_values=True)
@@ -108,15 +108,15 @@ class MultipartitePlan(BaseModel):
     id: UUID4
     """The unique id number of the multipartite plan"""
 
-    segments: list[SegmentPlan]
+    segments: list[Segment]
 
     @property
-    def required_segments(self) -> list[SegmentPlan]:
+    def required_segments(self) -> list[Segment]:
         """Return a list of segments that are required by all additions."""
         return [segment for segment in self.segments if segment.required]
 
     @classmethod
-    def new(cls, segments: list["SegmentPlan"]) -> "MultipartitePlan":
+    def new(cls, segments: list["Segment"]) -> "MultipartitePlan":
         """Initialize a MultipartitePlan from a list of segments."""
         return MultipartitePlan(
             id=uuid4(),

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -1,10 +1,10 @@
 import re
 from enum import StrEnum
+from typing import Union
 
-from pydantic import UUID4, BaseModel, ConfigDict, computed_field
+from pydantic import UUID4, BaseModel, ConfigDict, TypeAdapter
 from pydantic.dataclasses import dataclass
 
-from ref_builder.models import Molecule
 from ref_builder.ncbi.models import NCBIGenbank, NCBISourceMolType
 
 SIMPLE_NAME_PATTERN = re.compile(r"([A-Za-z0-9])+")
@@ -97,6 +97,11 @@ class MultipartitePlan(BaseModel):
     def required_segments(self) -> list[SegmentPlan]:
         """Return a list of segments that are required by all additions."""
         return [segment for segment in self.segments if segment.required]
+
+
+IsolatePlan = Union[MultipartitePlan, MonopartitePlan]
+
+plan_typer = TypeAdapter(IsolatePlan)
 
 
 def determine_segment_prefix(moltype: NCBISourceMolType) -> str:

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -1,6 +1,7 @@
 import re
 from enum import StrEnum
 from typing import Annotated, Literal, Union
+from uuid import uuid4
 
 from pydantic import UUID4, BaseModel, ConfigDict, Field, TypeAdapter
 from pydantic.dataclasses import dataclass
@@ -87,6 +88,16 @@ class MonopartitePlan(BaseModel):
     def required_segments(self) -> list["MonopartitePlan"]:
         return [self]
 
+    @classmethod
+    def new(cls, length: int, name: SegmentName | None = None) -> "MonopartitePlan":
+        """Initialize a MonopartitePlan from a list of segments."""
+        return MonopartitePlan(
+            id=uuid4(),
+            plan_type="monopartite",
+            length=length,
+            name=name,
+        )
+
 
 class MultipartitePlan(BaseModel):
     """Expected segments for an acceptable multipartite isolate."""
@@ -103,6 +114,15 @@ class MultipartitePlan(BaseModel):
     def required_segments(self) -> list[SegmentPlan]:
         """Return a list of segments that are required by all additions."""
         return [segment for segment in self.segments if segment.required]
+
+    @classmethod
+    def new(cls, segments: list["SegmentPlan"]) -> "MultipartitePlan":
+        """Initialize a MultipartitePlan from a list of segments."""
+        return MultipartitePlan(
+            id=uuid4(),
+            plan_type="multipartite",
+            segments=segments,
+        )
 
 
 IsolatePlan = Annotated[Union[MultipartitePlan, MonopartitePlan], Field(discriminator="plan_type")]

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -125,7 +125,9 @@ class MultipartitePlan(BaseModel):
         )
 
 
-IsolatePlan = Annotated[Union[MultipartitePlan, MonopartitePlan], Field(discriminator="plan_type")]
+IsolatePlan = Annotated[
+    Union[MultipartitePlan, MonopartitePlan], Field(discriminator="plan_type")
+]
 
 
 def determine_segment_prefix(moltype: NCBISourceMolType) -> str:

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -58,7 +58,7 @@ class Segment(SegmentMetadata):
 
     model_config = ConfigDict(use_enum_values=True)
 
-    name: SegmentName
+    name: SegmentName | None
     """The name of the segment"""
 
     required: SegmentRule
@@ -81,12 +81,21 @@ class MonopartitePlan(BaseModel):
     """The name of the monopartite plan"""
 
     @property
-    def segments(self) -> list["MonopartitePlan"]:
-        return [self]
+    def segments(self) -> list[Segment]:
+        """Return a simulated single-segment list of segments."""
+        return [
+            Segment(
+                id=self.id,
+                length=self.length,
+                name=self.name,
+                required=SegmentRule.REQUIRED,
+            )
+        ]
 
     @property
-    def required_segments(self) -> list["MonopartitePlan"]:
-        return [self]
+    def required_segments(self) -> list[Segment]:
+        """Return a simulated single-segment list of segments."""
+        return self.segments
 
     @classmethod
     def new(cls, length: int, name: SegmentName | None = None) -> "MonopartitePlan":

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -405,10 +405,10 @@ class Repo:
 
         return new_sequence
 
-    def set_isolate_plan(self, otu_id: uuid.UUID, plan: MonopartitePlan | MultipartitePlan) -> MonopartitePlan | MultipartitePlan:
+    def set_isolate_plan(
+        self, otu_id: uuid.UUID, plan: MonopartitePlan | MultipartitePlan
+    ) -> MonopartitePlan | MultipartitePlan:
         """Set the isolate plan for an OTU."""
-        otu = self.get_otu(otu_id)
-
         self._write_event(
             CreatePlan,
             CreatePlanData(plan=plan),
@@ -416,7 +416,6 @@ class Repo:
         )
 
         return self.get_otu(otu_id).plan
-
 
     def set_repr_isolate(self, otu_id: uuid.UUID, isolate_id: uuid.UUID) -> uuid.UUID:
         """Set the representative isolate for an OTU."""

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -405,6 +405,19 @@ class Repo:
 
         return new_sequence
 
+    def set_isolate_plan(self, otu_id: uuid.UUID, plan: MonopartitePlan | MultipartitePlan) -> MonopartitePlan | MultipartitePlan:
+        """Set the isolate plan for an OTU."""
+        otu = self.get_otu(otu_id)
+
+        self._write_event(
+            CreatePlan,
+            CreatePlanData(plan=plan),
+            OTUQuery(otu_id=otu_id),
+        )
+
+        return self.get_otu(otu_id).plan
+
+
     def set_repr_isolate(self, otu_id: uuid.UUID, isolate_id: uuid.UUID) -> uuid.UUID:
         """Set the representative isolate for an OTU."""
         otu = self.get_otu(otu_id)

--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from pydantic import UUID4, BaseModel, Field, field_serializer, field_validator
 
 from ref_builder.models import Molecule
-from ref_builder.plan import MonopartitePlan, MultipartitePlan
+from ref_builder.plan import IsolatePlan, MonopartitePlan, MultipartitePlan
 from ref_builder.utils import Accession, DataType, IsolateName
 
 
@@ -233,7 +233,7 @@ class RepoOTU(BaseModel):
     molecule: Molecule
     """The type of molecular information contained in this OTU."""
 
-    plan: MonopartitePlan | MultipartitePlan
+    plan: IsolatePlan
     """The schema of the OTU"""
 
     taxid: int

--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from pydantic import UUID4, BaseModel, Field, field_serializer, field_validator
 
 from ref_builder.models import Molecule
-from ref_builder.plan import IsolatePlan, MonopartitePlan, MultipartitePlan
+from ref_builder.plan import Plan, MonopartitePlan, MultipartitePlan
 from ref_builder.utils import Accession, DataType, IsolateName
 
 
@@ -233,7 +233,7 @@ class RepoOTU(BaseModel):
     molecule: Molecule
     """The type of molecular information contained in this OTU."""
 
-    plan: IsolatePlan
+    plan: Plan
     """The schema of the OTU"""
 
     taxid: int

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -12,6 +12,7 @@
     }),
     'name': 'Cabbage leaf curl Jamaica virus',
     'plan': dict({
+      'plan_type': 'multipartite',
       'segments': list([
         dict({
           'length': 2575,
@@ -60,6 +61,7 @@
     'plan': dict({
       'length': 342,
       'name': None,
+      'plan_type': 'monopartite',
     }),
     'taxid': 1278205,
   })
@@ -77,6 +79,7 @@
     }),
     'name': 'Cabbage leaf curl Jamaica virus',
     'plan': dict({
+      'plan_type': 'multipartite',
       'segments': list([
         dict({
           'length': 2575,

--- a/tests/__snapshots__/test_modify.ambr
+++ b/tests/__snapshots__/test_modify.ambr
@@ -1,6 +1,7 @@
 # serializer version: 1
 # name: TestSetIsolatePlan.test_add_segments_to_plan
   dict({
+    'plan_type': 'multipartite',
     'segments': list([
       dict({
         'length': 7219,
@@ -31,6 +32,7 @@
 # ---
 # name: TestSetIsolatePlan.test_resize_monopartite_plan
   dict({
+    'plan_type': 'multipartite',
     'segments': list([
       dict({
         'length': 7219,

--- a/tests/__snapshots__/test_modify.ambr
+++ b/tests/__snapshots__/test_modify.ambr
@@ -1,0 +1,31 @@
+# serializer version: 1
+# name: TestSetIsolatePlan.test_add_segments_to_plan
+  dict({
+    'segments': list([
+      dict({
+        'length': 7219,
+        'name': dict({
+          'key': 'L',
+          'prefix': 'RNA',
+        }),
+        'required': 'required',
+      }),
+      dict({
+        'length': 1613,
+        'name': dict({
+          'key': 'M',
+          'prefix': 'RNA',
+        }),
+        'required': 'required',
+      }),
+      dict({
+        'length': 1291,
+        'name': dict({
+          'key': 'S',
+          'prefix': 'RNA',
+        }),
+        'required': 'optional',
+      }),
+    ]),
+  })
+# ---

--- a/tests/__snapshots__/test_modify.ambr
+++ b/tests/__snapshots__/test_modify.ambr
@@ -29,3 +29,33 @@
     ]),
   })
 # ---
+# name: TestSetIsolatePlan.test_resize_monopartite_plan
+  dict({
+    'segments': list([
+      dict({
+        'length': 7219,
+        'name': dict({
+          'key': 'L',
+          'prefix': 'RNA',
+        }),
+        'required': 'required',
+      }),
+      dict({
+        'length': 1613,
+        'name': dict({
+          'key': 'M',
+          'prefix': 'RNA',
+        }),
+        'required': 'recommended',
+      }),
+      dict({
+        'length': 1291,
+        'name': dict({
+          'key': 'S',
+          'prefix': 'RNA',
+        }),
+        'required': 'recommended',
+      }),
+    ]),
+  })
+# ---

--- a/tests/ref/__snapshots__/test_schema.ambr
+++ b/tests/ref/__snapshots__/test_schema.ambr
@@ -1,12 +1,74 @@
 # serializer version: 1
-# name: TestIsolatePlan.test_serialize_plan[accessions0-MonopartitePlan]
+# name: TestPlan.test_create_monopartite_plan_from_records
   dict({
     'length': 7424,
     'name': None,
     'plan_type': 'monopartite',
   })
 # ---
-# name: TestIsolatePlan.test_serialize_plan[accessions1-MultipartitePlan]
+# name: TestPlan.test_create_multipartite_plan_from_records
+  dict({
+    'plan_type': 'multipartite',
+    'segments': list([
+      dict({
+        'length': 1090,
+        'name': dict({
+          'key': 'N',
+          'prefix': 'DNA',
+        }),
+        'required': 'required',
+      }),
+      dict({
+        'length': 1057,
+        'name': dict({
+          'key': 'U3',
+          'prefix': 'DNA',
+        }),
+        'required': 'required',
+      }),
+      dict({
+        'length': 1087,
+        'name': dict({
+          'key': 'S',
+          'prefix': 'DNA',
+        }),
+        'required': 'required',
+      }),
+      dict({
+        'length': 1074,
+        'name': dict({
+          'key': 'M',
+          'prefix': 'DNA',
+        }),
+        'required': 'required',
+      }),
+      dict({
+        'length': 1015,
+        'name': dict({
+          'key': 'C',
+          'prefix': 'DNA',
+        }),
+        'required': 'required',
+      }),
+      dict({
+        'length': 1099,
+        'name': dict({
+          'key': 'R',
+          'prefix': 'DNA',
+        }),
+        'required': 'required',
+      }),
+    ]),
+  })
+# ---
+# name: TestPlan.test_serialize_plan[accessions0-MonopartitePlan]
+  dict({
+    'length': 7424,
+    'name': None,
+    'plan_type': 'monopartite',
+  })
+# ---
+# name: TestPlan.test_serialize_plan[accessions1-MultipartitePlan]
   dict({
     'plan_type': 'multipartite',
     'segments': list([

--- a/tests/ref/__snapshots__/test_schema.ambr
+++ b/tests/ref/__snapshots__/test_schema.ambr
@@ -3,10 +3,12 @@
   dict({
     'length': 7424,
     'name': None,
+    'plan_type': 'monopartite',
   })
 # ---
 # name: TestIsolatePlan.test_serialize_plan[accessions1-MultipartitePlan]
   dict({
+    'plan_type': 'multipartite',
     'segments': list([
       dict({
         'length': 1090,

--- a/tests/ref/test_schema.py
+++ b/tests/ref/test_schema.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import TypeAdapter
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
 
@@ -6,14 +7,17 @@ from ref_builder.ncbi.client import NCBIClient
 from ref_builder.ncbi.models import NCBISourceMolType
 from ref_builder.otu.utils import create_isolate_plan_from_records
 from ref_builder.plan import (
+    IsolatePlan,
     MonopartitePlan,
     MultipartitePlan,
-    plan_typer,
     SegmentName,
     get_multipartite_segment_name,
     parse_segment_name,
 )
 from tests.fixtures.factories import NCBIGenbankFactory, NCBISourceFactory
+
+
+plan_typer = TypeAdapter(IsolatePlan)
 
 
 @pytest.mark.parametrize(

--- a/tests/ref/test_schema.py
+++ b/tests/ref/test_schema.py
@@ -7,7 +7,7 @@ from ref_builder.ncbi.client import NCBIClient
 from ref_builder.ncbi.models import NCBISourceMolType
 from ref_builder.otu.utils import create_isolate_plan_from_records
 from ref_builder.plan import (
-    IsolatePlan,
+    Plan,
     MonopartitePlan,
     MultipartitePlan,
     SegmentName,
@@ -17,7 +17,7 @@ from ref_builder.plan import (
 from tests.fixtures.factories import NCBIGenbankFactory, NCBISourceFactory
 
 
-plan_typer = TypeAdapter(IsolatePlan)
+plan_typer = TypeAdapter(Plan)
 
 
 class TestPlan:

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -79,9 +79,19 @@ class TestSetIsolatePlan:
         assert otu_after.plan == new_isolate_plan
 
     def test_replace_isolate_plan(self, scratch_repo: Repo):
-        otu_before = scratch_repo.get_otu_by_taxid(3158377)
+        otu_before = scratch_repo.get_otu_by_taxid(2164102)
 
-        replace_isolate_plan(scratch_repo, otu_before, [])
+        new_plan = replace_isolate_plan(
+            scratch_repo,
+            otu_before,
+            ["NC_055390", "NC_055391", "NC_055392"]
+        )
+
+        otu_after = scratch_repo.get_otu(otu_before.id)
+
+        assert otu_after.plan == new_plan
+
+        assert otu_after.plan != otu_before.plan
 
     def test_add_segments_to_plan(
         self,

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -46,9 +46,7 @@ class TestSetIsolatePlan:
 
         assert type(original_plan) is MultipartitePlan
 
-        new_isolate_plan = MultipartitePlan(
-            id=uuid4(), segments=original_plan.segments
-        )
+        new_isolate_plan = MultipartitePlan(id=uuid4(), segments=original_plan.segments)
 
         new_isolate_plan.segments.append(
             SegmentPlan(
@@ -82,9 +80,7 @@ class TestSetIsolatePlan:
         otu_before = scratch_repo.get_otu_by_taxid(2164102)
 
         new_plan = replace_isolate_plan(
-            scratch_repo,
-            otu_before,
-            ["NC_055390", "NC_055391", "NC_055392"]
+            scratch_repo, otu_before, ["NC_055390", "NC_055391", "NC_055392"]
         )
 
         otu_after = scratch_repo.get_otu(otu_before.id)
@@ -113,7 +109,7 @@ class TestSetIsolatePlan:
             precached_repo,
             otu_before,
             rule=SegmentRule.OPTIONAL,
-            accessions=["MF062138"]
+            accessions=["MF062138"],
         )
 
         assert len(expanded_plan.segments) == len(original_plan.segments) + 1

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -11,7 +11,6 @@ from ref_builder.otu.update import (
     add_genbank_isolate,
     add_segments_to_plan,
     promote_otu_accessions,
-    replace_isolate_plan,
     set_isolate_plan,
     set_representative_isolate,
 )
@@ -75,21 +74,6 @@ class TestSetIsolatePlan:
         assert len(otu_after.plan.segments) == len(otu_before.plan.segments) + 2
 
         assert otu_after.plan == new_isolate_plan
-
-    def test_replace_isolate_plan(self, scratch_repo: Repo):
-        otu_before = scratch_repo.get_otu_by_taxid(345184)
-
-        assert otu_before
-
-        new_plan = replace_isolate_plan(
-            scratch_repo, otu_before, ["NC_038792", "NC_038793"]
-        )
-
-        otu_after = scratch_repo.get_otu(otu_before.id)
-
-        assert otu_after.plan == new_plan
-
-        assert otu_after.plan != otu_before.plan
 
     def test_add_segments_to_plan(
         self,

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -14,7 +14,13 @@ from ref_builder.otu.update import (
     set_isolate_plan,
     set_representative_isolate,
 )
-from ref_builder.plan import MultipartitePlan, SegmentName, SegmentRule, SegmentPlan
+from ref_builder.plan import (
+    MonopartitePlan,
+    MultipartitePlan,
+    SegmentName,
+    SegmentRule,
+    SegmentPlan,
+)
 
 
 def test_update_representative_isolate(scratch_repo: Repo):
@@ -105,6 +111,25 @@ class TestSetIsolatePlan:
         assert otu_after.plan != otu_before.plan
 
         assert otu_after.plan.model_dump() == snapshot(exclude=props("id"))
+
+    def test_extend_plan_monopartite_fail(
+        self,
+        scratch_repo: Repo,
+    ):
+        """Test that add_segments_to_plan() fails out
+        when the original plan is a MonopartitePlan.
+        """
+        otu_before = scratch_repo.get_otu_by_taxid(96892)
+
+        assert type(otu_before.plan) is MonopartitePlan
+
+        with pytest.raises(ValueError):
+            add_segments_to_plan(
+                scratch_repo,
+                otu_before,
+                rule=SegmentRule.OPTIONAL,
+                accessions=["NC_010620"],
+            )
 
 
 class TestUpdateRepresentativeIsolateCommand:

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -20,7 +20,7 @@ from ref_builder.plan import (
     MultipartitePlan,
     SegmentName,
     SegmentRule,
-    SegmentPlan,
+    Segment,
 )
 
 
@@ -59,7 +59,7 @@ class TestSetIsolatePlan:
         )
 
         new_isolate_plan.segments.append(
-            SegmentPlan(
+            Segment(
                 id=uuid4(),
                 length=2000,
                 name=SegmentName(prefix="DNA", key="C"),
@@ -68,7 +68,7 @@ class TestSetIsolatePlan:
         )
 
         new_isolate_plan.segments.append(
-            SegmentPlan(
+            Segment(
                 id=uuid4(),
                 length=1000,
                 name=SegmentName(prefix="DNA", key="Z"),

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -52,7 +52,11 @@ class TestSetIsolatePlan:
 
         assert type(original_plan) is MultipartitePlan
 
-        new_isolate_plan = MultipartitePlan(id=uuid4(), segments=original_plan.segments)
+        new_isolate_plan = MultipartitePlan(
+            plan_type="multipartite",
+            id=uuid4(),
+            segments=original_plan.segments,
+        )
 
         new_isolate_plan.segments.append(
             SegmentPlan(

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -77,10 +77,12 @@ class TestSetIsolatePlan:
         assert otu_after.plan == new_isolate_plan
 
     def test_replace_isolate_plan(self, scratch_repo: Repo):
-        otu_before = scratch_repo.get_otu_by_taxid(2164102)
+        otu_before = scratch_repo.get_otu_by_taxid(345184)
+
+        assert otu_before
 
         new_plan = replace_isolate_plan(
-            scratch_repo, otu_before, ["NC_055390", "NC_055391", "NC_055392"]
+            scratch_repo, otu_before, ["NC_038792", "NC_038793"]
         )
 
         otu_after = scratch_repo.get_otu(otu_before.id)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -27,7 +27,7 @@ def initialized_repo(empty_repo: Repo):
             topology=Topology.LINEAR,
         ),
         name="Tobacco mosaic virus",
-        plan=MonopartitePlan(id=uuid4(), length=150),
+        plan=MonopartitePlan.new(length=150),
         taxid=12242,
     )
 
@@ -59,7 +59,7 @@ def init_otu(empty_repo: Repo) -> RepoOTU:
             topology=Topology.LINEAR,
         ),
         name="Tobacco mosaic virus",
-        plan=MonopartitePlan(id=uuid4(), length=150),
+        plan=MonopartitePlan.new(length=150),
         taxid=12242,
     )
 
@@ -96,7 +96,7 @@ class TestCreateOTU:
         """Test that creating an OTU returns the expected ``RepoOTU`` object and creates
         the expected event file.
         """
-        monopartite_plan = MonopartitePlan(id=uuid4(), length=150)
+        monopartite_plan = MonopartitePlan.new(length=150)
 
         otu = empty_repo.create_otu(
             acronym="TMV",
@@ -123,7 +123,11 @@ class TestCreateOTU:
             ),
             name="Tobacco mosaic virus",
             repr_isolate=None,
-            plan=MonopartitePlan(id=monopartite_plan.id, length=150),
+            plan=MonopartitePlan(
+                id=monopartite_plan.id,
+                plan_type="monopartite",
+                length=150,
+            ),
             taxid=12242,
             isolates=[],
         )
@@ -148,6 +152,7 @@ class TestCreateOTU:
                     "id": str(monopartite_plan.id),
                     "length": 150,
                     "name": None,
+                    "plan_type": "monopartite",
                 },
                 "taxid": 12242,
             },
@@ -173,7 +178,7 @@ class TestCreateOTU:
                 topology=Topology.LINEAR,
             ),
             name="Tobacco mosaic virus",
-            plan=MonopartitePlan(id=uuid4(), length=150),
+            plan=MonopartitePlan.new(length=150),
             taxid=12242,
         )
 
@@ -190,7 +195,7 @@ class TestCreateOTU:
                     topology=Topology.LINEAR,
                 ),
                 name="Tobacco mosaic virus",
-                plan=MonopartitePlan(id=uuid4(), length=150),
+                plan=MonopartitePlan.new(length=150),
                 taxid=438782,
             )
 
@@ -207,7 +212,7 @@ class TestCreateOTU:
                 topology=Topology.LINEAR,
             ),
             name="Tobacco mosaic virus",
-            plan=MonopartitePlan(id=uuid4(), length=150),
+            plan=MonopartitePlan.new(length=150),
             taxid=12242,
         )
 
@@ -224,7 +229,7 @@ class TestCreateOTU:
                 ),
                 legacy_id="abcd1234",
                 name="Abaca bunchy top virus",
-                plan=MonopartitePlan(id=uuid4(), length=150),
+                plan=MonopartitePlan.new(length=150),
                 taxid=438782,
             )
 
@@ -373,7 +378,7 @@ class TestGetOTU:
         """Test that getting an OTU returns the expected ``RepoOTU`` object including two
         isolates with one sequence each.
         """
-        monopartite_plan = MonopartitePlan(id=uuid4(), length=150)
+        monopartite_plan = MonopartitePlan.new(length=150)
 
         otu = empty_repo.create_otu(
             acronym="TMV",
@@ -466,7 +471,7 @@ class TestGetOTU:
             ),
             name="Tobacco mosaic virus",
             repr_isolate=None,
-            plan=MonopartitePlan(id=monopartite_plan.id, length=150),
+            plan=MonopartitePlan(id=monopartite_plan.id, plan_type="monopartite", length=150),
             taxid=12242,
             isolates=otu_contents,
         )

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -471,7 +471,9 @@ class TestGetOTU:
             ),
             name="Tobacco mosaic virus",
             repr_isolate=None,
-            plan=MonopartitePlan(id=monopartite_plan.id, plan_type="monopartite", length=150),
+            plan=MonopartitePlan(
+                id=monopartite_plan.id, plan_type="monopartite", length=150
+            ),
             taxid=12242,
             isolates=otu_contents,
         )

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -72,7 +72,7 @@ class TestOTU:
             ),
             name="Tobacco mosaic virus",
             repr_isolate=None,
-            plan=MonopartitePlan(id=uuid4(), length=6395),
+            plan=MonopartitePlan.new(length=6395),
             taxid=12242,
         )
 


### PR DESCRIPTION
* add `ref-builder otu update TAXID plan extend [ACCESSIONS] --optional`
* add `ref-builder otu update TAXID plan multipartite  --name [prefix, key] --optional [ACCESSIONS]`
* add `otu.update.set_isolate_plan()` to directly access replacement
* allow `Segment.name = None`