### PR TITLE
fix: fetch all accessions associated with a taxonomy id

### DIFF
--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -156,7 +156,6 @@ class NCBIClient:
         :return: A list of Genbank accessions
         """
         page = 1
-
         accessions = []
 
         # If there are more than 1000 accessions, we need to paginate.
@@ -166,29 +165,20 @@ class NCBIClient:
                     db=NCBIDatabase.NUCCORE,
                     term=f"txid{taxid}[orgn]",
                     idtype="acc",
-                    retstart=page * ESEARCH_PAGE_SIZE,
+                    retstart=(page - 1) * ESEARCH_PAGE_SIZE,
                     retmax=ESEARCH_PAGE_SIZE,
                 )
 
             result = Entrez.read(handle)
 
-            accessions.extend(result["IdList"])
+            accessions += result["IdList"]
 
-            if int(result["Count"]) < ESEARCH_PAGE_SIZE:
+            if int(result["Count"]) <= ESEARCH_PAGE_SIZE:
                 break
 
             page += 1
 
-        with log_http_error():
-            handle = Entrez.esearch(
-                db=NCBIDatabase.NUCCORE,
-                term=f"txid{taxid}[orgn]",
-                idtype="acc",
-                retstart=0,
-                retmax=1000,
-            )
-
-        return Entrez.read(handle)["IdList"]
+        return accessions
 
     @staticmethod
     def validate_genbank_records(records: list[dict]) -> list[NCBIGenbank]:


### PR DESCRIPTION
* Make sure accessions are properly paged through.

The previous commit related to this was totally incorrect.

