### PR TITLE
update tests; improve logging in `ncbi.client`, `otu.update`

### DIFF
--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -21,7 +21,7 @@ if email := os.environ.get("NCBI_EMAIL"):
 if api_key := os.environ.get("NCBI_API_KEY"):
     Entrez.api_key = os.environ.get("NCBI_API_KEY")
 
-base_logger = get_logger()
+base_logger = get_logger("ncbi")
 
 ESEARCH_PAGE_SIZE = 1000
 """The number of results to fetch per page in an Entrez esearch query."""

--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -83,7 +83,7 @@ class NCBIClient:
                 )
             if uncached_accessions:
                 logger.debug(
-                    f"Uncached accessions found",
+                    "Uncached accessions found",
                     uncached_accessions=uncached_accessions,
                 )
 

--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -76,10 +76,16 @@ class NCBIClient:
             if records:
                 logger.debug(
                     f"Loaded {len(records)} cached records",
-                    cached_accessions=[record.get(GenbankRecordKey.PRIMARY_ACCESSION) for record in records]
+                    cached_accessions=[
+                        record.get(GenbankRecordKey.PRIMARY_ACCESSION)
+                        for record in records
+                    ],
                 )
             if uncached_accessions:
-                logger.debug(f"Uncached accessions found", uncached_accessions=uncached_accessions)
+                logger.debug(
+                    f"Uncached accessions found",
+                    uncached_accessions=uncached_accessions,
+                )
 
         fetch_list = list(
             set(accessions)

--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -66,12 +66,20 @@ class NCBIClient:
         logger = base_logger.bind(accessions=accessions)
 
         if not self.ignore_cache:
+            uncached_accessions = []
+
             for accession in accessions:
                 record = self.cache.load_genbank_record(accession)
                 if record is not None:
                     records.append(record)
-                else:
-                    logger.debug("Missing accession", missing_accession=accession)
+
+            if records:
+                logger.debug(
+                    f"Loaded {len(records)} cached records",
+                    cached_accessions=[record.get(GenbankRecordKey.PRIMARY_ACCESSION) for record in records]
+                )
+            if uncached_accessions:
+                logger.debug(f"Uncached accessions found", uncached_accessions=uncached_accessions)
 
         fetch_list = list(
             set(accessions)

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -763,7 +763,7 @@ def promote_otu_accessions_from_records(
 
     if promoted_accessions:
         otu_logger.debug(
-            f"Promoted records",
+            "Promoted records",
             count=len(promoted_accessions),
             promoted_accessions=sorted(promoted_accessions),
         )

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -495,7 +495,10 @@ def auto_update_otu(
 
     accessions = ncbi.fetch_accessions_by_taxid(otu.taxid)
 
-    fetch_list = sorted(set(Accession.from_string(accession).key for accession in accessions) - otu.blocked_accessions)
+    fetch_list = sorted(
+        set(Accession.from_string(accession).key for accession in accessions)
+        - otu.blocked_accessions
+    )
 
     if fetch_list:
         logger.debug(
@@ -685,17 +688,23 @@ def promote_otu_accessions(
 
     otu_logger = logger.bind(otu_id=otu.id, taxid=otu.taxid)
 
-    otu_logger.debug("Checking for promotable records", accessions=sorted(otu.accessions))
+    otu_logger.debug(
+        "Checking for promotable records", accessions=sorted(otu.accessions)
+    )
 
     accessions = ncbi.fetch_accessions_by_taxid(otu.taxid)
     fetch_list = sorted(
-        set(Accession.from_string(accession).key for accession in accessions) - otu.blocked_accessions
+        set(Accession.from_string(accession).key for accession in accessions)
+        - otu.blocked_accessions
     )
 
     if fetch_list:
         records = ncbi.fetch_genbank_records(fetch_list)
 
-        otu_logger.debug(f"New accessions found. Checking for promotable records.", fetch_list=fetch_list)
+        otu_logger.debug(
+            f"New accessions found. Checking for promotable records.",
+            fetch_list=fetch_list,
+        )
 
         return promote_otu_accessions_from_records(repo, otu, records)
 
@@ -755,7 +764,7 @@ def promote_otu_accessions_from_records(
     if promoted_accessions:
         otu_logger.debug(
             f"Promoted f{len(promoted_accessions)} records",
-            promoted_accessions=sorted(promoted_accessions)
+            promoted_accessions=sorted(promoted_accessions),
         )
     else:
         otu_logger.debug("All accessions are up to date")

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -496,7 +496,7 @@ def auto_update_otu(
     accessions = ncbi.fetch_accessions_by_taxid(otu.taxid)
 
     fetch_list = sorted(
-        set(Accession.from_string(accession).key for accession in accessions)
+        {Accession.from_string(accession).key for accession in accessions}
         - otu.blocked_accessions
     )
 
@@ -708,7 +708,7 @@ def promote_otu_accessions(
 
         return promote_otu_accessions_from_records(repo, otu, records)
 
-    otu_logger.info("Extant records are up to date.")
+    otu_logger.info("Records are already up to date.")
 
 
 def promote_otu_accessions_from_records(
@@ -763,7 +763,8 @@ def promote_otu_accessions_from_records(
 
     if promoted_accessions:
         otu_logger.debug(
-            f"Promoted f{len(promoted_accessions)} records",
+            f"Promoted records",
+            count=len(promoted_accessions),
             promoted_accessions=sorted(promoted_accessions),
         )
     else:

--- a/tests/__snapshots__/test_add.ambr
+++ b/tests/__snapshots__/test_add.ambr
@@ -102,32 +102,3 @@
     'taxid': 345184,
   })
 # ---
-# name: TestUpdateOTU.test_without_exclusions_ok
-  dict({
-    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='1148-13'): set({
-      'MF062130',
-      'MF062131',
-      'MF062132',
-    }),
-    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='4342-5'): set({
-      'MF062136',
-      'MF062137',
-      'MF062138',
-    }),
-    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='982-11'): set({
-      'NC_055390',
-      'NC_055391',
-      'NC_055392',
-    }),
-    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='BR-Mishima'): set({
-      'MK936225',
-      'MK936226',
-      'MK936227',
-    }),
-    IsolateName(type=<IsolateNameType.ISOLATE: 'isolate'>, value='Pe2'): set({
-      'OQ420743',
-      'OQ420744',
-      'OQ420745',
-    }),
-  })
-# ---

--- a/tests/__snapshots__/test_update.ambr
+++ b/tests/__snapshots__/test_update.ambr
@@ -1,0 +1,69 @@
+# serializer version: 1
+# name: TestUpdateOTU.test_with_replacement_ok
+  dict({
+    'Isolate 1148-13': set({
+      'MF062130',
+      'MF062131',
+      'MF062132',
+    }),
+    'Isolate 4342-5': set({
+      'MF062136',
+      'MF062137',
+      'MF062138',
+    }),
+    'Isolate 982-11': set({
+      'NC_055390',
+      'NC_055391',
+      'NC_055392',
+    }),
+    'Isolate A13': set({
+      'OR889795',
+      'OR889796',
+      'OR889797',
+    }),
+    'Isolate BR-Mishima': set({
+      'MK936225',
+      'MK936226',
+      'MK936227',
+    }),
+    'Isolate Pe2': set({
+      'OQ420743',
+      'OQ420744',
+      'OQ420745',
+    }),
+  })
+# ---
+# name: TestUpdateOTU.test_without_exclusions_ok
+  dict({
+    'Isolate 1148-13': set({
+      'MF062130',
+      'MF062131',
+      'MF062132',
+    }),
+    'Isolate 4342-5': set({
+      'MF062136',
+      'MF062137',
+      'MF062138',
+    }),
+    'Isolate 982-11': set({
+      'NC_055390',
+      'NC_055391',
+      'NC_055392',
+    }),
+    'Isolate A13': set({
+      'OR889795',
+      'OR889796',
+      'OR889797',
+    }),
+    'Isolate BR-Mishima': set({
+      'MK936225',
+      'MK936226',
+      'MK936227',
+    }),
+    'Isolate Pe2': set({
+      'OQ420743',
+      'OQ420744',
+      'OQ420745',
+    }),
+  })
+# ---

--- a/tests/__snapshots__/test_update.ambr
+++ b/tests/__snapshots__/test_update.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestUpdateOTU.test_with_replacement_ok
+# name: TestUpdateOTU.test_ok
   dict({
     'Isolate 1148-13': set({
       'MF062130',
@@ -33,7 +33,7 @@
     }),
   })
 # ---
-# name: TestUpdateOTU.test_without_exclusions_ok
+# name: TestUpdateOTU.test_with_refseq_replacement_ok
   dict({
     'Isolate 1148-13': set({
       'MF062130',

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -13,7 +13,6 @@ from ref_builder.otu.update import (
     add_and_name_isolate,
     add_genbank_isolate,
     add_unnamed_isolate,
-    auto_update_otu,
     delete_isolate_from_otu,
     replace_sequence_in_otu,
     update_isolate_from_accessions,
@@ -331,116 +330,6 @@ class TestAddIsolate:
         )
 
         assert add_genbank_isolate(precached_repo, otu, accessions) is None
-
-
-@pytest.mark.ncbi()
-class TestUpdateOTU:
-    def test_without_exclusions_ok(
-        self,
-        precached_repo: Repo,
-        snapshot: SnapshotAssertion,
-    ):
-        otu_before = create_otu(
-            precached_repo,
-            2164102,
-            ["MF062136", "MF062137", "MF062138"],
-            "",
-        )
-
-        assert otu_before.accessions == {"MF062136", "MF062137", "MF062138"}
-
-        auto_update_otu(precached_repo, otu_before)
-
-        otu_after = precached_repo.get_otu(otu_before.id)
-
-        assert otu_after.id == otu_before.id
-
-        assert otu_after.isolate_ids.issuperset(otu_before.isolate_ids)
-
-        assert {
-            isolate.name: isolate.accessions for isolate in otu_after.isolates
-        } == snapshot()
-
-        assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}
-
-        assert otu_after.accessions == {
-            "MF062136",
-            "MF062137",
-            "MF062138",
-            "MF062130",
-            "MF062131",
-            "MF062132",
-            "MK936225",
-            "MK936226",
-            "MK936227",
-            "OQ420743",
-            "OQ420744",
-            "OQ420745",
-            "NC_055390",
-            "NC_055391",
-            "NC_055392",
-        }
-
-    def test_with_replacement_ok(
-        self,
-        precached_repo: Repo,
-        snapshot: SnapshotAssertion,
-    ):
-        otu_before = create_otu(
-            precached_repo,
-            2164102,
-            ["MF062125", "MF062126", "MF062127"],
-            "",
-        )
-
-        assert (
-            otu_before.accessions
-            == otu_before.get_isolate(otu_before.repr_isolate).accessions
-            == {"MF062125", "MF062126", "MF062127"}
-        )
-
-        auto_update_otu(precached_repo, otu_before)
-
-        otu_after = precached_repo.get_otu(otu_before.id)
-
-        assert otu_after.get_isolate(otu_after.repr_isolate).accessions == {
-            "NC_055390",
-            "NC_055391",
-            "NC_055392",
-        }
-
-        assert {"MF062125", "MF062126", "MF062127"}.isdisjoint(otu_after.accessions)
-
-        assert otu_after.repr_isolate == otu_before.repr_isolate
-
-        assert (
-            otu_after.get_isolate(otu_before.repr_isolate).accessions
-            != otu_before.get_isolate(otu_before.repr_isolate).accessions
-        )
-
-        assert otu_after.id == otu_before.id
-
-        assert otu_after.isolate_ids.issuperset(otu_before.isolate_ids)
-
-        assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}
-
-        assert otu_after.accessions == {
-            "MF062136",
-            "MF062137",
-            "MF062138",
-            "MF062130",
-            "MF062131",
-            "MF062132",
-            "MK936225",
-            "MK936226",
-            "MK936227",
-            "OQ420743",
-            "OQ420744",
-            "OQ420745",
-            "NC_055390",
-            "NC_055391",
-            "NC_055392",
-        }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,129 @@
+import pytest
+from syrupy import SnapshotAssertion
+
+from ref_builder.otu.create import create_otu
+from ref_builder.otu.update import auto_update_otu
+from ref_builder.repo import Repo
+
+
+@pytest.mark.ncbi()
+class TestUpdateOTU:
+    """Test automatic OTU update functionality."""
+
+    def test_without_exclusions_ok(
+        self,
+        precached_repo: Repo,
+        snapshot: SnapshotAssertion,
+    ):
+        """"""
+        otu_before = create_otu(
+            precached_repo,
+            2164102,
+            ["MF062136", "MF062137", "MF062138"],
+            "",
+        )
+
+        assert otu_before.accessions == {"MF062136", "MF062137", "MF062138"}
+
+        auto_update_otu(precached_repo, otu_before)
+
+        otu_after = precached_repo.get_otu(otu_before.id)
+
+        assert otu_after.id == otu_before.id
+
+        assert otu_after.isolate_ids.issuperset(otu_before.isolate_ids)
+
+        assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}
+
+        assert otu_after.accessions == {
+            "MF062136",
+            "MF062137",
+            "MF062138",
+            "MF062130",
+            "MF062131",
+            "MF062132",
+            "MK936225",
+            "MK936226",
+            "MK936227",
+            "OQ420743",
+            "OQ420744",
+            "OQ420745",
+            "NC_055390",
+            "NC_055391",
+            "NC_055392",
+            "OR889795",
+            "OR889796",
+            "OR889797",
+        }
+
+        assert {
+           str(isolate.name): isolate.accessions for isolate in otu_after.isolates
+        } == snapshot()
+
+    def test_with_replacement_ok(
+        self,
+        precached_repo: Repo,
+        snapshot: SnapshotAssertion,
+    ):
+        otu_before = create_otu(
+            precached_repo,
+            2164102,
+            ["MF062125", "MF062126", "MF062127"],
+            "",
+        )
+
+        assert (
+            otu_before.accessions
+            == otu_before.get_isolate(otu_before.repr_isolate).accessions
+            == {"MF062125", "MF062126", "MF062127"}
+        )
+
+        auto_update_otu(precached_repo, otu_before)
+
+        otu_after = precached_repo.get_otu(otu_before.id)
+
+        assert otu_after.get_isolate(otu_after.repr_isolate).accessions == {
+            "NC_055390",
+            "NC_055391",
+            "NC_055392",
+        }
+
+        assert {"MF062125", "MF062126", "MF062127"}.isdisjoint(otu_after.accessions)
+
+        assert otu_after.repr_isolate == otu_before.repr_isolate
+
+        assert (
+            otu_after.get_isolate(otu_before.repr_isolate).accessions
+            != otu_before.get_isolate(otu_before.repr_isolate).accessions
+        )
+
+        assert otu_after.id == otu_before.id
+
+        assert otu_after.isolate_ids.issuperset(otu_before.isolate_ids)
+
+        assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}
+
+        assert otu_after.accessions == {
+            "MF062136",
+            "MF062137",
+            "MF062138",
+            "MF062130",
+            "MF062131",
+            "MF062132",
+            "MK936225",
+            "MK936226",
+            "MK936227",
+            "OQ420743",
+            "OQ420744",
+            "OQ420745",
+            "NC_055390",
+            "NC_055391",
+            "NC_055392",
+            "OR889795",
+            "OR889796",
+            "OR889797",
+        }
+
+        assert {
+            str(isolate.name): isolate.accessions for isolate in otu_after.isolates
+        } == snapshot()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -10,38 +10,44 @@ from ref_builder.repo import Repo
 class TestUpdateOTU:
     """Test automatic OTU update functionality."""
 
-    def test_without_exclusions_ok(
+    def test_ok(
         self,
         precached_repo: Repo,
         snapshot: SnapshotAssertion,
     ):
-        """"""
+        """Test automatic update behaviour."""
         otu_before = create_otu(
             precached_repo,
             2164102,
-            ["MF062136", "MF062137", "MF062138"],
+            ["NC_055390", "NC_055391", "NC_055392"],
             "",
         )
 
-        assert otu_before.accessions == {"MF062136", "MF062137", "MF062138"}
+        assert otu_before.accessions == {"NC_055390", "NC_055391", "NC_055392"}
+
+        assert otu_before.blocked_accessions == {
+            "NC_055390",
+            "NC_055391",
+            "NC_055392",
+        }.union({"MF062125", "MF062126", "MF062127"})
 
         auto_update_otu(precached_repo, otu_before)
 
         otu_after = precached_repo.get_otu(otu_before.id)
 
+        assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}
+
         assert otu_after.id == otu_before.id
 
         assert otu_after.isolate_ids.issuperset(otu_before.isolate_ids)
 
-        assert otu_after.excluded_accessions == {"MF062125", "MF062126", "MF062127"}
-
         assert otu_after.accessions == {
-            "MF062136",
-            "MF062137",
-            "MF062138",
             "MF062130",
             "MF062131",
             "MF062132",
+            "MF062136",
+            "MF062137",
+            "MF062138",
             "MK936225",
             "MK936226",
             "MK936227",
@@ -57,14 +63,15 @@ class TestUpdateOTU:
         }
 
         assert {
-           str(isolate.name): isolate.accessions for isolate in otu_after.isolates
+            str(isolate.name): isolate.accessions for isolate in otu_after.isolates
         } == snapshot()
 
-    def test_with_replacement_ok(
+    def test_with_refseq_replacement_ok(
         self,
         precached_repo: Repo,
         snapshot: SnapshotAssertion,
     ):
+        """Test that automatic update replaces superceded accessions with RefSeq versions."""
         otu_before = create_otu(
             precached_repo,
             2164102,

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -29,7 +29,10 @@ class TestUpdateOTU:
             "NC_055390",
             "NC_055391",
             "NC_055392",
-        }.union({"MF062125", "MF062126", "MF062127"})
+            "MF062125",
+            "MF062126",
+            "MF062127",
+        }
 
         auto_update_otu(precached_repo, otu_before)
 


### PR DESCRIPTION
* `test_add::TestUpdate` moved to new `test_update` to isolate its heavier server dependency
* update accession lists in `TestUpdate` for new accessions
* clean up logging in `NCBIClient.fetch_genbank_records()`