### PR TITLE
ECO-95 (partial): Reject new monopartite sequences with invalid lengths

### DIFF
--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -215,7 +215,7 @@ def create_isolate_from_records(
         if not check_sequence_length(
             records[0].sequence,
             segment_length=otu.plan.length,
-            tolerance=repo.settings.default_segment_length_tolerance,
+            tolerance=otu.plan.length_tolerance,
         ):
             isolate_logger.error(
                 "Sequence does not conform to plan length.",

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -8,6 +8,8 @@ from ref_builder.ncbi.models import NCBIGenbank
 from ref_builder.otu.utils import (
     DeleteRationale,
     RefSeqConflictError,
+    create_segments_from_records,
+    check_sequence_length,
     group_genbank_records_by_isolate,
     parse_refseq_comment,
 )
@@ -74,6 +76,15 @@ def add_genbank_isolate(
         )
         return None
 
+    if type(otu.plan) is MonopartitePlan:
+        if not check_sequence_length(
+            records[0].sequence,
+            segment_length=otu.plan.length,
+            tolerance=repo.settings.default_segment_length_tolerance
+        ):
+            otu_logger.error("Sequence does not conform to plan length.", accession=accessions)
+            return None
+
     if (isolate_id := otu.get_isolate_id_by_name(isolate_name)) is not None:
         otu_logger.debug(f"{isolate_name} already exists in this OTU")
 
@@ -129,6 +140,15 @@ def add_unnamed_isolate(
 
     records = ncbi.fetch_genbank_records(fetch_list)
 
+    if type(otu.plan) is MonopartitePlan:
+        if not check_sequence_length(
+            records[0].sequence,
+            segment_length=otu.plan.length,
+            tolerance=repo.settings.default_segment_length_tolerance
+        ):
+            otu_logger.error("Sequence does not conform to plan length.", accession=accessions)
+            return None
+
     return create_isolate_from_records(
         repo,
         otu,
@@ -171,6 +191,15 @@ def add_and_name_isolate(
     )
 
     records = ncbi.fetch_genbank_records(fetch_list)
+
+    if type(otu.plan) is MonopartitePlan:
+        if not check_sequence_length(
+            records[0].sequence,
+            segment_length=otu.plan.length,
+            tolerance=repo.settings.default_segment_length_tolerance
+        ):
+            otu_logger.error("Sequence does not conform to plan length.", accession=accessions)
+            return None
 
     return create_isolate_from_records(
         repo,

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -140,15 +140,6 @@ def add_unnamed_isolate(
 
     records = ncbi.fetch_genbank_records(fetch_list)
 
-    if type(otu.plan) is MonopartitePlan:
-        if not check_sequence_length(
-            records[0].sequence,
-            segment_length=otu.plan.length,
-            tolerance=repo.settings.default_segment_length_tolerance
-        ):
-            otu_logger.error("Sequence does not conform to plan length.", accession=accessions)
-            return None
-
     return create_isolate_from_records(
         repo,
         otu,
@@ -192,15 +183,6 @@ def add_and_name_isolate(
 
     records = ncbi.fetch_genbank_records(fetch_list)
 
-    if type(otu.plan) is MonopartitePlan:
-        if not check_sequence_length(
-            records[0].sequence,
-            segment_length=otu.plan.length,
-            tolerance=repo.settings.default_segment_length_tolerance
-        ):
-            otu_logger.error("Sequence does not conform to plan length.", accession=accessions)
-            return None
-
     return create_isolate_from_records(
         repo,
         otu,
@@ -223,6 +205,21 @@ def create_isolate_from_records(
         otu_name=otu.name,
         taxid=otu.taxid,
     )
+
+    if type(otu.plan) is MonopartitePlan:
+        if not check_sequence_length(
+            records[0].sequence,
+            segment_length=otu.plan.length,
+            tolerance=repo.settings.default_segment_length_tolerance
+        ):
+            isolate_logger.error(
+                "Sequence does not conform to plan length.",
+                accession=records[0].accession,
+                sequence_length=len(records[0].sequence),
+                plan_length=otu.plan.length,
+            )
+
+            return None
 
     try:
         isolate = repo.create_isolate(

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -80,9 +80,11 @@ def add_genbank_isolate(
         if not check_sequence_length(
             records[0].sequence,
             segment_length=otu.plan.length,
-            tolerance=repo.settings.default_segment_length_tolerance
+            tolerance=repo.settings.default_segment_length_tolerance,
         ):
-            otu_logger.error("Sequence does not conform to plan length.", accession=accessions)
+            otu_logger.error(
+                "Sequence does not conform to plan length.", accession=accessions
+            )
             return None
 
     if (isolate_id := otu.get_isolate_id_by_name(isolate_name)) is not None:
@@ -199,6 +201,9 @@ def create_isolate_from_records(
 ) -> RepoIsolate | None:
     """Take a list of GenBank records that make up a new isolate
     and add them to the OTU.
+
+    If a monopartite sequence is outside of recommended length bounds,
+    automatically reject the isolate and return None.
     """
     isolate_logger = get_logger("otu.isolate").bind(
         isolate_name=str(isolate_name) if IsolateName is not None else None,
@@ -210,7 +215,7 @@ def create_isolate_from_records(
         if not check_sequence_length(
             records[0].sequence,
             segment_length=otu.plan.length,
-            tolerance=repo.settings.default_segment_length_tolerance
+            tolerance=repo.settings.default_segment_length_tolerance,
         ):
             isolate_logger.error(
                 "Sequence does not conform to plan length.",

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -138,7 +138,10 @@ def parse_refseq_comment(comment: str) -> tuple[str, str]:
 
     match = refseq_pattern.search(comment)
 
-    return match.group(1), match.group(2)
+    if match:
+        return match.group(1), match.group(2)
+
+    raise ValueError("Invalid RefSeq comment")
 
 
 def get_molecule_from_records(records: list[NCBIGenbank]) -> Molecule:

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -163,6 +163,17 @@ def get_molecule_from_records(records: list[NCBIGenbank]) -> Molecule:
     )
 
 
+def check_sequence_length(sequence: str, segment_length: int, tolerance: float) -> bool:
+    if (
+        len(sequence) < segment_length * (1.0 - tolerance)
+        or len(sequence) > segment_length * (1.0 + tolerance)
+    ):
+        return False
+
+    return True
+
+
+
 def _get_isolate_name(record: NCBIGenbank) -> IsolateName | None:
     """Get the isolate name from a Genbank record."""
     if record.source.model_fields_set.intersection(

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -167,14 +167,12 @@ def get_molecule_from_records(records: list[NCBIGenbank]) -> Molecule:
 
 
 def check_sequence_length(sequence: str, segment_length: int, tolerance: float) -> bool:
-    if (
-        len(sequence) < segment_length * (1.0 - tolerance)
-        or len(sequence) > segment_length * (1.0 + tolerance)
-    ):
+    if len(sequence) < segment_length * (1.0 - tolerance) or len(
+        sequence
+    ) > segment_length * (1.0 + tolerance):
         return False
 
     return True
-
 
 
 def _get_isolate_name(record: NCBIGenbank) -> IsolateName | None:

--- a/tests/__snapshots__/test_console.ambr
+++ b/tests/__snapshots__/test_console.ambr
@@ -28,19 +28,19 @@
   
   ISOLATES
   
-  Isolate organization
+  Isolate while
   
-   ACCESSION    SEGMENT  DEFINITION                              
-   I48166.1     DNA R    Stand audience who artist travel sell.  
-   J64270.1     DNA S    Campaign college director less.         
-   NC_167153.1  DNA M    Support wind good training main forget. 
+   ACCESSION    SEGMENT  DEFINITION                                  
+   I48166.1     DNA R    Stand audience who artist travel sell.      
+   NC_022895.1  DNA M    And down get it remember try music until.   
+   NC_996421.1  DNA S    Enough really positive something pay trial. 
   
-  Isolate present
+  Isolate look
   
-   ACCESSION    SEGMENT  DEFINITION                                      
-   NC_132006.1  DNA M    Pull foot culture.                              
-   NC_134696.1  DNA R    Poor beyond interest finally require wish most. 
-   NC_795643.1  DNA S    Character game tell result marriage very.       
+   ACCESSION    SEGMENT  DEFINITION                                          
+   NC_662533.1  DNA M    Recently draw audience them community need success. 
+   NC_941664.1  DNA R    Size field career continue vote tree third.         
+   NC_953301.1  DNA S    Determine garden why meet.                          
   
   '''
 # ---

--- a/tests/fixtures/providers.py
+++ b/tests/fixtures/providers.py
@@ -82,14 +82,16 @@ class BusinessProvider(BaseProvider):
 class SequenceProvider(BaseProvider):
     """Dummy sequence data provider."""
 
-    def sequence(self) -> str:
+    def sequence(
+        self, min: int = 100, max: int = 10000,
+    ) -> str:
         """Return a pseudorandom string consisting of
         acceptable genetic sequence letters.
         """
         return "".join(
             self.random_elements(
                 NUCLEOTIDE_PROBABILITIES,
-                self.random_int(MIN_SEQUENCE_LENGTH, MAX_SEQUENCE_LENGTH),
+                self.random_int(min, max),
                 use_weighting=True,
             ),
         )

--- a/tests/fixtures/providers.py
+++ b/tests/fixtures/providers.py
@@ -83,7 +83,9 @@ class SequenceProvider(BaseProvider):
     """Dummy sequence data provider."""
 
     def sequence(
-        self, min: int = 100, max: int = 10000,
+        self,
+        min: int = 100,
+        max: int = 10000,
     ) -> str:
         """Return a pseudorandom string consisting of
         acceptable genetic sequence letters.

--- a/tests/ref/test_inclusion_checks.py
+++ b/tests/ref/test_inclusion_checks.py
@@ -15,10 +15,12 @@ faker.add_provider(SequenceProvider)
 
 
 def create_mock_record(
-    otu: RepoOTU, sequence_length: int,
+    otu: RepoOTU,
+    sequence_length: int,
 ) -> NCBIGenbank:
     mock_record_source = NCBISourceFactory.build(
-        taxid=otu.taxid, organism=otu.name,
+        taxid=otu.taxid,
+        organism=otu.name,
     )
 
     mock_record = NCBIGenbankFactory.build(
@@ -76,10 +78,7 @@ class TestSequenceLengthCheck:
 class TestAddMonopartiteIsolate:
     """Test that new monopartite isolates follow plan length limits."""
 
-    @pytest.mark.parametrize(
-        "sequence_length_multiplier",
-        [1.0, 1.03, 0.98]
-    )
+    @pytest.mark.parametrize("sequence_length_multiplier", [1.0, 1.03, 0.98])
     def test_ok(self, scratch_repo, sequence_length_multiplier: float):
         """Test that sequences within recommended length variance
         are added without issue."""
@@ -105,10 +104,7 @@ class TestAddMonopartiteIsolate:
 
         assert mock_record.accession in otu_after.accessions
 
-    @pytest.mark.parametrize(
-        "sequence_length_multiplier",
-        [0.5, 1.035, 20.0]
-    )
+    @pytest.mark.parametrize("sequence_length_multiplier", [0.5, 1.035, 20.0])
     def test_fail(self, scratch_repo, sequence_length_multiplier: float):
         """Test that sequences that exceed recommended length variance
         are automatically rejected.

--- a/tests/ref/test_inclusion_checks.py
+++ b/tests/ref/test_inclusion_checks.py
@@ -1,0 +1,52 @@
+import pytest
+from faker import Faker
+
+from ref_builder.otu.utils import check_sequence_length
+from tests.fixtures.providers import SequenceProvider
+
+
+faker = Faker()
+faker.add_provider(SequenceProvider)
+
+
+class TestSequenceLengthCheck:
+    """Test sequence length check functions."""
+
+    @pytest.mark.parametrize(
+        ("sequence_lengths", "tolerance"),
+        [
+            ([1000, 970, 1030], 0.03),
+            ([1000, 980, 1020], 0.02),
+            ([1000, 960, 1040], 0.04),
+        ],
+    )
+    def test_check_sequence_length_function_success(
+        self, sequence_lengths: list[int], tolerance: float
+    ):
+        """Test that check_sequence_length() returns True
+        given different sequences and tolerance levels.
+        """
+        for sequence_length in sequence_lengths:
+            fake_sequence = faker.sequence(min=sequence_length, max=sequence_length)
+
+            assert check_sequence_length(fake_sequence, 1000, tolerance)
+
+    @pytest.mark.parametrize(
+        ("sequence_lengths", "tolerance"),
+        [
+            ([970, 1030], 0.02),
+            ([969, 1031], 0.03),
+            ([979, 1021], 0.02),
+            ([959, 1041], 0.04),
+        ],
+    )
+    def test_check_sequence_length_function_fail(
+        self, sequence_lengths: list[int], tolerance: float
+    ):
+        """Test that check_sequence_length() returns False
+        given different sequences and tolerance levels.
+        """
+        for sequence_length in sequence_lengths:
+            fake_sequence = faker.sequence(min=sequence_length, max=sequence_length)
+
+            assert not check_sequence_length(fake_sequence, 1000, tolerance)

--- a/tests/ref/test_inclusion_checks.py
+++ b/tests/ref/test_inclusion_checks.py
@@ -1,12 +1,33 @@
 import pytest
 from faker import Faker
 
-from ref_builder.otu.utils import check_sequence_length
-from tests.fixtures.providers import SequenceProvider
+from ref_builder.resources import RepoOTU
+from ref_builder.ncbi.models import NCBIGenbank
+from ref_builder.otu.update import create_isolate_from_records
+from ref_builder.otu.utils import check_sequence_length, IsolateName, IsolateNameType
+from tests.fixtures.factories import NCBIGenbankFactory, NCBISourceFactory
+from tests.fixtures.providers import AccessionProvider, SequenceProvider
 
 
 faker = Faker()
+faker.add_provider(AccessionProvider)
 faker.add_provider(SequenceProvider)
+
+
+def create_mock_record(
+    otu: RepoOTU, sequence_length: int,
+) -> NCBIGenbank:
+    mock_record_source = NCBISourceFactory.build(
+        taxid=otu.taxid, organism=otu.name,
+    )
+
+    mock_record = NCBIGenbankFactory.build(
+        accession=faker.genbank_accession(),
+        source=mock_record_source,
+        sequence=faker.sequence(min=sequence_length, max=sequence_length),
+    )
+
+    return mock_record
 
 
 class TestSequenceLengthCheck:
@@ -50,3 +71,66 @@ class TestSequenceLengthCheck:
             fake_sequence = faker.sequence(min=sequence_length, max=sequence_length)
 
             assert not check_sequence_length(fake_sequence, 1000, tolerance)
+
+
+class TestAddMonopartiteIsolate:
+    """Test that new monopartite isolates follow plan length limits."""
+
+    @pytest.mark.parametrize(
+        "sequence_length_multiplier",
+        [1.0, 1.03, 0.98]
+    )
+    def test_ok(self, scratch_repo, sequence_length_multiplier: float):
+        """Test that sequences within recommended length variance
+        are added without issue."""
+        otu_before = scratch_repo.get_otu_by_taxid(270478)
+
+        mock_record = create_mock_record(
+            otu_before,
+            int(otu_before.plan.length * sequence_length_multiplier),
+        )
+
+        assert mock_record
+
+        mock_isolate = create_isolate_from_records(
+            scratch_repo,
+            otu_before,
+            isolate_name=IsolateName(type=IsolateNameType.ISOLATE, value="mock"),
+            records=[mock_record],
+        )
+
+        otu_after = scratch_repo.get_otu_by_taxid(270478)
+
+        assert mock_isolate.id in otu_after.isolate_ids
+
+        assert mock_record.accession in otu_after.accessions
+
+    @pytest.mark.parametrize(
+        "sequence_length_multiplier",
+        [0.5, 1.035, 20.0]
+    )
+    def test_fail(self, scratch_repo, sequence_length_multiplier: float):
+        """Test that sequences that exceed recommended length variance
+        are automatically rejected.
+        """
+        otu_before = scratch_repo.get_otu_by_taxid(270478)
+
+        mock_record = create_mock_record(
+            otu_before,
+            int(otu_before.plan.length * sequence_length_multiplier),
+        )
+
+        assert mock_record
+
+        mock_isolate = create_isolate_from_records(
+            scratch_repo,
+            otu_before,
+            isolate_name=IsolateName(type=IsolateNameType.ISOLATE, value="mock"),
+            records=[mock_record],
+        )
+
+        assert mock_isolate is None
+
+        otu_after = scratch_repo.get_otu_by_taxid(270478)
+
+        assert mock_record.accession not in otu_after.accessions

--- a/tests/ref/test_utils.py
+++ b/tests/ref/test_utils.py
@@ -45,13 +45,14 @@ def test_format_json(tmp_path: Path):
 
 class TestRefSeqCommentParser:
     """Test the parsing of standardized RefSeq comments."""
+
     @pytest.mark.parametrize(
         ("comment_string", "status", "predecessor_accession"),
         [
             (
                 "PROVISIONAL REFSEQ: "
                 "This record has not yet been subject to final NCBI review. "
-                "The reference sequence is identical to EF546808," 
+                "The reference sequence is identical to EF546808,"
                 "COMPLETENESS: full length.",
                 "PROVISIONAL REFSEQ",
                 "EF546808",


### PR DESCRIPTION
* feat: reject monopartite sequences that fall outside of the mandated length tolerance
* add `otu.utils.check_sequence_length()`
* add `test_inclusion_checks`
