### PR TITLE
Revise logging

### DIFF
--- a/ref_builder/cli/main.py
+++ b/ref_builder/cli/main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from uuid import UUID
 
 import click
+import structlog
 from click import Context
 
 from ref_builder.build import build_json
@@ -38,12 +39,18 @@ from ref_builder.utils import DataType, IsolateName, IsolateNameType, format_jso
 PRECACHE_BUFFER_SIZE = 450
 """The number of Genbank records to fetch in a single request when pre-caching."""
 
+logger = structlog.get_logger()
+
 
 @click.group()
 @click.option("--debug", is_flag=True, help="Show debug logs")
-def entry(debug: bool) -> None:
+@click.option("-v", "--verbose", "verbosity", count=True)
+def entry(debug: bool, verbosity: int) -> None:
     """Build and maintain reference sets of pathogen genome sequences."""
-    configure_logger(debug)
+    if debug:
+        verbosity = 2
+
+    configure_logger(verbosity)
 
 
 @entry.command()

--- a/ref_builder/logs.py
+++ b/ref_builder/logs.py
@@ -4,7 +4,11 @@ import structlog
 
 
 def configure_logger(verbosity: int) -> None:
-    """Configure structlog-based logging."""
+    """Configure structlog-based logging.
+
+    :param verbosity: The verbosity level of the logger.
+    """
+    # Disable faker logging.
     logging.getLogger("faker").setLevel(logging.ERROR)
 
     processors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, TypeAdapter
 from pytest_mock import MockerFixture
 
 from ref_builder.legacy.utils import build_legacy_otu
+from ref_builder.logs import configure_logger
 from ref_builder.ncbi.cache import NCBICache
 from ref_builder.ncbi.client import NCBIClient
 from ref_builder.otu.create import create_otu
@@ -17,6 +18,8 @@ from ref_builder.otu.update import update_otu_with_accessions
 from ref_builder.repo import Repo
 from ref_builder.resources import RepoOTU
 from ref_builder.utils import Accession, DataType
+
+configure_logger(True)
 
 
 @pytest.fixture()


### PR DESCRIPTION
* Only show logging above `WARNING` when `-v`, `-vv`, or `--debug` are set.
* Focus on `structlog` features in configuration, minimizing use of `logging`.

The idea with this is to progressively use `rich` to render the results of operations. Logging
should be focused on output for development troubleshooting.

