### PR TITLE
fix: `Repo.exclude_accessions()` omits `OTU.accessions` contents

### DIFF
--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -518,6 +518,13 @@ class Repo:
             )
             return otu.excluded_accessions
 
+        if unremovable_accessions := excludable_accessions.intersection(otu.accessions):
+            logger.warning(
+                "Accessions currently in OTU cannot be removed.",
+                unremovable_accessions=sorted(unremovable_accessions),
+            )
+            excludable_accessions -= unremovable_accessions
+
         if (
             extant_requested_accessions := excludable_accessions
             & otu.excluded_accessions
@@ -547,6 +554,8 @@ class Repo:
                 new_excluded_accessions=sorted(excludable_accessions),
                 old_excluded_accessions=sorted(otu.excluded_accessions),
             )
+        else:
+            logger.warning("No excludable accessions were given.")
 
         return self.get_otu(otu_id).excluded_accessions
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -880,21 +880,17 @@ class TestExcludeAccessions:
 
         del event["timestamp"]
 
-        assert (
-            event.data.accessions
-            == ["TM100024"]
-            == {
-                "data": {
-                    "accessions": ["TM100024"],
-                    "action": "exclude",
-                },
-                "id": 4,
-                "query": {
-                    "otu_id": str(otu_id),
-                },
-                "type": "UpdateExcludedAccessions",
-            }
-        )
+        assert event == {
+            "data": {
+                "accessions": ["TM100024"],
+                "action": "exclude",
+            },
+            "id": 4,
+            "query": {
+                "otu_id": str(otu_id),
+            },
+            "type": "UpdateExcludedAccessions",
+        }
 
 
 class TestAllowAccessions:

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -708,49 +708,6 @@ class TestGetIsolate:
         assert isolate_unnamed_after.accessions == {"EMPTY1", "EMPTY2"}
 
 
-def test_exclude_accession(empty_repo: Repo):
-    """Test that excluding an accession from an OTU writes the expected event file and
-    returns the expected OTU objects.
-    """
-    otu = init_otu(empty_repo)
-
-    assert empty_repo.last_id == 2
-
-    empty_repo.exclude_accession(otu.id, "TMVABC.1")
-
-    assert empty_repo.last_id == 3
-
-    with open(empty_repo.path.joinpath("src", f"{empty_repo.last_id:08}.json")) as f:
-        event = orjson.loads(f.read())
-
-    del event["timestamp"]
-
-    assert event == {
-        "data": {
-            "accessions": ["TMVABC.1"],
-            "action": "exclude",
-        },
-        "id": 3,
-        "query": {
-            "otu_id": str(otu.id),
-        },
-        "type": "UpdateExcludedAccessions",
-    }
-
-    assert empty_repo.get_otu(otu.id).excluded_accessions == {
-        "TMVABC.1",
-    }
-
-    empty_repo.exclude_accession(otu.id, "ABTV")
-
-    assert empty_repo.last_id == 4
-
-    assert empty_repo.get_otu(otu.id).excluded_accessions == {
-        "TMVABC.1",
-        "ABTV",
-    }
-
-
 class TestExcludeAccessions:
     """Test that accessions can be excluded from future fetches."""
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -813,6 +813,29 @@ class TestExcludeAccessions:
 
         assert otu_after.excluded_accessions == mock_accessions | {"TM100024"}
 
+    def test_fail(self, initialized_repo: Repo):
+        """Test that an extant accession cannot be added to the excluded accessions."""
+        otu_before = initialized_repo.get_otu_by_taxid(12242)
+
+        assert otu_before.excluded_accessions == set()
+
+        extant_accession = next(iter(otu_before.accessions))
+
+        initialized_repo.exclude_accessions(otu_before.id, {extant_accession})
+
+        otu_after = initialized_repo.get_otu_by_taxid(12242)
+
+        assert otu_after.excluded_accessions == set()
+
+        with open(
+            initialized_repo.path.joinpath(
+                "src", f"0000000{initialized_repo.last_id}.json"
+            )
+        ) as f:
+            event = orjson.loads(f.read())
+
+            assert event["type"] != "UpdateExcludedAccessions"
+
 
 class TestAllowAccessions:
     """Test that accessions allowed back into the OTU are no longer contained

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -769,9 +769,7 @@ class TestExcludeAccessions:
 
         assert empty_repo.last_id == 3
 
-        with open(
-            empty_repo.path.joinpath("src", f"{empty_repo.last_id:08}.json")
-        ) as f:
+        with open(empty_repo.path / "src" / f"{empty_repo.last_id:08}.json") as f:
             event = orjson.loads(f.read())
 
         del event["timestamp"]
@@ -818,7 +816,7 @@ class TestExcludeAccessions:
         assert initialized_repo.last_id == 5
 
         with open(
-            initialized_repo.path.joinpath("src", f"{initialized_repo.last_id:08}.json")
+            initialized_repo.path / "src" / f"{initialized_repo.last_id:08}.json"
         ) as f:
             event = orjson.loads(f.read())
 


### PR DESCRIPTION
* add `TestExcludeAccessions.test_fail()`
* remove `test_exclude_accession()`