### PR TITLE
ECO-109: Show segment name instead of ID for `otu get`

### DIFF
--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -22,6 +22,10 @@ def print_otu(otu: RepoOTU) -> None:
     :param otu: The OTU to print.
 
     """
+    id_to_segment_name_table = {
+        str(segment.id): segment.name for segment in otu.plan.segments
+    }
+
     console.print(f"[bold][underline]{otu.name}[/bold][/underline]")
     console.line()
 
@@ -101,9 +105,11 @@ def print_otu(otu: RepoOTU) -> None:
         isolate_table.add_column("DEFINITION")
 
         for sequence in sorted(isolate.sequences, key=lambda s: s.accession):
+            segment_name = id_to_segment_name_table[sequence.segment]
+
             isolate_table.add_row(
                 _render_nucleotide_link(str(sequence.accession)),
-                sequence.segment,
+                "N/A" if segment_name is None else str(segment_name),
                 sequence.definition,
             )
 

--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -22,8 +22,8 @@ def print_otu(otu: RepoOTU) -> None:
     :param otu: The OTU to print.
 
     """
-    id_to_segment_name_table = {
-        str(segment.id): segment.name for segment in otu.plan.segments
+    id_to_segment_name = {
+        str(segment.id): str(segment.name or "N/A") for segment in otu.plan.segments
     }
 
     console.print(f"[bold][underline]{otu.name}[/bold][/underline]")
@@ -105,11 +105,9 @@ def print_otu(otu: RepoOTU) -> None:
         isolate_table.add_column("DEFINITION")
 
         for sequence in sorted(isolate.sequences, key=lambda s: s.accession):
-            segment_name = id_to_segment_name_table[sequence.segment]
-
             isolate_table.add_row(
                 _render_nucleotide_link(str(sequence.accession)),
-                "N/A" if segment_name is None else str(segment_name),
+                id_to_segment_name[sequence.segment],
                 sequence.definition,
             )
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -84,7 +84,7 @@ def test_print_otu(snapshot: SnapshotAssertion):
                 definition=fake.sentence(),
                 legacy_id=None,
                 sequence=fake.sequence(),
-                segment=str(segment.name),
+                segment=str(segment.id),
             )
             for segment in otu.plan.segments
         ]


### PR DESCRIPTION
* add `segment.id` -> `segment.name` conversion to `print_otu()`
* fix outdated sequence generation in `test_print_otu()`