### PR TITLE
fix: `NCBIClient.fetch_accessions_by_taxid()` infinite loop

### DIFF
--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -197,7 +197,7 @@ class NCBIClient:
 
             base_logger.debug(
                 "Large fetch. May take longer than expected...",
-                result_count=int(result["Count"]),
+                result_count=result_count,
                 page=page,
                 page_size=ESEARCH_PAGE_SIZE,
                 taxid=taxid,

--- a/ref_builder/ncbi/client.py
+++ b/ref_builder/ncbi/client.py
@@ -188,6 +188,9 @@ class NCBIClient:
 
             result = Entrez.read(handle)
 
+            if not result["IdList"]:
+                break
+
             result_count = int(result["Count"])
 
             accessions += result["IdList"]

--- a/tests/ncbi/test_client.py
+++ b/tests/ncbi/test_client.py
@@ -123,6 +123,12 @@ class TestFetchAccessionsByTaxid:
         """Test that the client returns an empty list when the taxid does not exist."""
         assert NCBIClient.fetch_accessions_by_taxid(99999999) == []
 
+    def test_giant_ok(self):
+        """Test that the client returns a list of results when the accession list
+        is long enough to force pagination.
+        """
+        assert len(NCBIClient.fetch_accessions_by_taxid(12585)) > 1000
+
 
 class TestFetchTaxonomy:
     @pytest.mark.ncbi()


### PR DESCRIPTION
* address infinite loop bug in `NCBIClient.fetch_accessions_by_taxid()` (bug took place because `result["Count"]` returns total count, not page count)
* add corresponding test