### PR TITLE
UX Fixes

### DIFF
--- a/ref_builder/build.py
+++ b/ref_builder/build.py
@@ -61,7 +61,7 @@ def build_json(indent: bool, output_path: Path, path: Path, version: str) -> Non
 
             isolates.append(
                 {
-                    "id": isolate.legacy_id or isolate.id,
+                    "id": isolate.legacy_id or str(isolate.id),
                     "default": isolate.id == otu.representative_isolate,
                     "sequences": sequences,
                     "source_name": isolate.name.value

--- a/ref_builder/build.py
+++ b/ref_builder/build.py
@@ -73,7 +73,7 @@ def build_json(indent: bool, output_path: Path, path: Path, version: str) -> Non
                 },
             )
 
-        isolates.sort(key=lambda x: x["id"])
+        isolates.sort(key=lambda x: x["source_type"] + x["source_name"])
 
         molecule = _get_molecule_string(otu.molecule)
 

--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator
 
 import rich.console
 from rich.table import Table
+from rich.text import Text
 
 from ref_builder.models import OTUMinimal
 from ref_builder.plan import SegmentRule
@@ -22,7 +23,7 @@ def print_otu(otu: RepoOTU) -> None:
     :param otu: The OTU to print.
 
     """
-    console.print(f"[bold][underline]{otu.name}[/bold][/underline]")
+    console.print(Text(otu.name, style="bold underline"))
     console.line()
 
     table = Table(

--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -79,6 +79,8 @@ def print_otu(otu: RepoOTU) -> None:
     console.line()
     console.print("[bold]ISOLATES[/bold]")
 
+    index_by_segment_id = {segment.id: i for i, segment in enumerate(otu.plan.segments)}
+
     for isolate in otu.isolates:
         console.line()
         console.print(
@@ -97,11 +99,14 @@ def print_otu(otu: RepoOTU) -> None:
         isolate_table.add_column("SEGMENT", min_width=max_segment_name_length)
         isolate_table.add_column("DEFINITION")
 
-        for sequence in sorted(isolate.sequences, key=lambda s: s.accession):
+        for sequence in sorted(
+            isolate.sequences,
+            key=lambda s: index_by_segment_id[s.segment],
+        ):
             isolate_table.add_row(
                 _render_nucleotide_link(str(sequence.accession)),
                 str(len(sequence.sequence)),
-                str(otu.plan.get_segment_by_id(sequence.segment).name),
+                str(otu.plan.get_segment_by_id(sequence.segment).name or "Unnamed"),
                 sequence.definition,
             )
 

--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -81,8 +81,10 @@ def print_otu(otu: RepoOTU) -> None:
 
     for isolate in otu.isolates:
         console.line()
-        console.print(str(isolate.name)) if isolate.name is not None else console.print(
-            "[UNNAMED]",
+        console.print(
+            Text(str(isolate.name))
+        ) if isolate.name is not None else console.print(
+            "[italic]Unnamed[/italic]",
         )
         console.line()
 

--- a/ref_builder/console.py
+++ b/ref_builder/console.py
@@ -63,31 +63,15 @@ def print_otu(otu: RepoOTU) -> None:
     plan_table.add_column("TOLERANCE")
     plan_table.add_column("ID")
 
-    if not otu.plan.monopartite:
-        for segment in otu.plan.segments:
-            plan_table.add_row(
-                str(segment.name),
-                "[red]Yes[/red]"
-                if segment.required == SegmentRule.REQUIRED
-                else "[grey]No[/grey]",
-                str(segment.length),
-                str(segment.length_tolerance),
-                str(segment.id),
-            )
-    else:
-        monopartite_segment = otu.plan.segments[0]
-
-        segment_name = (
-            monopartite_segment.name
-            if monopartite_segment.name is not None
-            else "Unnamed"
-        )
-
+    for segment in otu.plan.segments:
         plan_table.add_row(
-            segment_name,
-            "[red]Yes[/red]",
-            str(monopartite_segment.length),
-            str(monopartite_segment.length_tolerance),
+            str("Unnamed" if segment.name is None else segment.name),
+            "[red]Yes[/red]"
+            if segment.required == SegmentRule.REQUIRED
+            else "[grey]No[/grey]",
+            str(segment.length),
+            str(segment.length_tolerance),
+            str(segment.id),
         )
 
     console.print(plan_table)

--- a/ref_builder/otu/isolate.py
+++ b/ref_builder/otu/isolate.py
@@ -60,7 +60,7 @@ def add_genbank_isolate(
         otu_logger.warning(
             e,
             isolate_name=str(isolate_name),
-            isolate_records=sorted(isolate_records.keys()),
+            accessions=sorted(isolate_records.keys()),
         )
         return None
 

--- a/tests/__snapshots__/test_console.ambr
+++ b/tests/__snapshots__/test_console.ambr
@@ -32,14 +32,14 @@
   
    ACCESSION    LENGTH  SEGMENT  DEFINITION                              
    I48166.1     591     DNA R    Stand audience who artist travel sell.  
-   J64270.1     286     DNA S    Campaign college director less.         
    NC_167153.1  422     DNA M    Support wind good training main forget. 
+   J64270.1     286     DNA S    Campaign college director less.         
   
   Isolate present
   
    ACCESSION    LENGTH  SEGMENT  DEFINITION                                      
-   NC_132006.1  781     DNA M    Pull foot culture.                              
    NC_134696.1  803     DNA R    Poor beyond interest finally require wish most. 
+   NC_132006.1  781     DNA M    Pull foot culture.                              
    NC_795643.1  138     DNA S    Character game tell result marriage very.       
   
   '''


### PR DESCRIPTION
- Pprevent error during build when serializing isolates with UUIDs.
- Sort built isolates by name.
- Console: Fix bad formatting of non-alpha characters in OTU names. Numbers in names would be colored differently.
- Console: Render mono and multipartite plans consistently. The two plan type previously had completely separate render code.
- Console: Italicize unnamed isolate names instead of `[Unnamed]`.
- Console: Sort `otu get` sequences by segment order.
