### PR TITLE
fix: handle incomplete and delimiter-less genbank segment names

### DIFF
--- a/ref_builder/legacy/convert.py
+++ b/ref_builder/legacy/convert.py
@@ -7,7 +7,7 @@ from ref_builder.legacy.utils import iter_legacy_otus
 from ref_builder.logs import configure_logger
 from ref_builder.models import Molecule
 from ref_builder.ncbi.client import NCBIClient
-from ref_builder.plan import Plan, Segment, SegmentName, SegmentRule, parse_segment_name
+from ref_builder.plan import Plan, Segment, SegmentName, SegmentRule
 from ref_builder.repo import Repo
 from ref_builder.utils import DataType, IsolateName, IsolateNameType
 
@@ -67,7 +67,7 @@ def convert_legacy_repo(name: str, path: Path, target_path: Path) -> None:
                 name = None
             else:
                 try:
-                    name = parse_segment_name(segment["name"])
+                    name = SegmentName.from_string(segment["name"])
                 except ValueError:
                     name = SegmentName(key=segment["name"], prefix=molecule.type)
 

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -191,7 +191,7 @@ def group_genbank_records_by_isolate(
     isolates = defaultdict(dict)
 
     for record in records:
-        isolate_name = _get_isolate_name(record)
+        isolate_name = _extract_isolate_name_from_record(record)
         if isolate_name is None:
             # Assume this is a monopartite OTU and do not group.
             continue

--- a/ref_builder/otu/utils.py
+++ b/ref_builder/otu/utils.py
@@ -13,6 +13,7 @@ from ref_builder.plan import (
     Segment,
     SegmentRule,
     extract_segment_name_from_record,
+    extract_segment_name_from_record_with_plan,
 )
 from ref_builder.utils import Accession, IsolateName, IsolateNameType
 
@@ -187,7 +188,7 @@ def group_genbank_records_by_isolate(
 
     for record in records:
         try:
-            isolate_name = _get_isolate_name(record)
+            isolate_name = _extract_isolate_name_from_record(record)
 
             if isolate_name is None:
                 logger.debug(
@@ -221,7 +222,7 @@ def parse_refseq_comment(comment: str) -> tuple[str, str]:
     raise ValueError("Invalid RefSeq comment")
 
 
-def _get_isolate_name(record: NCBIGenbank) -> IsolateName | None:
+def _extract_isolate_name_from_record(record: NCBIGenbank) -> IsolateName | None:
     """Get the isolate name from a Genbank record."""
     if record.source.model_fields_set.intersection(
         {IsolateNameType.ISOLATE, IsolateNameType.STRAIN, IsolateNameType.CLONE},
@@ -264,10 +265,8 @@ def assign_records_to_segments(
     :param plan: A plan.
     :return: A dictionary of segment IDs as keys and records as values.
     """
-    unassigned_segments = {segment.name: segment for segment in plan.segments}
-
     seen_segment_names = Counter(
-        extract_segment_name_from_record(record) for record in records
+        extract_segment_name_from_record_with_plan(record, plan) for record in records
     )
 
     if seen_segment_names.total() > 1 and seen_segment_names[None]:
@@ -275,6 +274,8 @@ def assign_records_to_segments(
             "If a segment has no name, it must be the only segment. Only monopartite "
             "plans may have unnamed segments."
         )
+
+    unassigned_segments = {segment.name: segment for segment in plan.segments}
 
     duplicate_segment_names = [
         segment_name for segment_name, count in seen_segment_names.items() if count > 1
@@ -311,6 +312,8 @@ def assign_records_to_segments(
         )
 
     return {
-        unassigned_segments[extract_segment_name_from_record(record)].id: record
+        unassigned_segments[
+            extract_segment_name_from_record_with_plan(record, plan)
+        ].id: record
         for record in records
     }

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -202,6 +202,14 @@ def extract_segment_name_from_record(record: NCBIGenbank) -> SegmentName | None:
     if (name := SegmentName.from_string(record.source.segment)) is not None:
         return name
 
+    # Handles common cases without delimiters
+    for moltype_prefix in ["DNA", "RNA"]:
+        if record.source.segment.startswith(moltype_prefix):
+            return SegmentName(
+                prefix=record.moltype,
+                key=record.source.segment[3:].strip(),
+            )
+
     if SIMPLE_NAME_PATTERN.fullmatch(record.source.segment):
         return SegmentName(
             prefix=record.moltype,

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -248,6 +248,37 @@ class TestExtractSegmentNameFromRecord:
             prefix=suffix, key=key
         )
 
+    @pytest.mark.parametrize("key", ["1", "A", "U3"])
+    @pytest.mark.parametrize(
+        "mol_type", [NCBISourceMolType.GENOMIC_RNA, NCBISourceMolType.GENOMIC_DNA]
+    )
+    def test_no_delimiter_ok(
+        self,
+        key: str,
+        mol_type: NCBISourceMolType,
+        ncbi_genbank_factory: NCBIGenbankFactory,
+        ncbi_source_factory: NCBISourceFactory,
+    ):
+        """Test that extract_segment_name_from_record() can handle undelimited segment names."""
+        match mol_type:
+            case NCBISourceMolType.GENOMIC_DNA:
+                prefix = "DNA"
+            case NCBISourceMolType.GENOMIC_RNA:
+                prefix = "RNA"
+            case _:
+                raise ValueError(f"{mol_type} may not be a valid NCBISourceMolType.")
+
+        record = ncbi_genbank_factory.build(
+            source=ncbi_source_factory.build(
+                mol_type=mol_type,
+                segment=prefix + key,
+            ),
+        )
+
+        assert extract_segment_name_from_record(record) == SegmentName(
+            prefix=prefix, key=key
+        )
+
     @pytest.mark.parametrize("key", ["", "V#", "51f9a0bc-7b3b-434f-bf4c-f7abaa015b8d"])
     @pytest.mark.parametrize(
         "mol_type", [NCBISourceMolType.GENOMIC_RNA, NCBISourceMolType.GENOMIC_DNA]

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from uuid import UUID, uuid4
 
 import pytest
@@ -11,7 +12,7 @@ from ref_builder.plan import (
     SegmentName,
     SegmentRule,
     extract_segment_name_from_record,
-    parse_segment_name,
+    extract_segment_name_from_record_with_plan,
 )
 from tests.fixtures.factories import NCBIGenbankFactory, NCBISourceFactory
 from tests.fixtures.utils import uuid_matcher
@@ -192,15 +193,15 @@ class TestPlan:
         assert plan.required_segments == [plan.segments[0], plan.segments[2]]
 
 
-class TestParseSegmentName:
+class TestSegmentName:
     """Test segment name normalization."""
 
     @pytest.mark.parametrize("delimiter", [" ", "_", "-"])
     @pytest.mark.parametrize("key", ["A", "BN", "U3"])
     @pytest.mark.parametrize("prefix", ["DNA", "RNA"])
-    def test_ok(self, delimiter: str, key: str, prefix: str):
+    def test_from_string(self, delimiter: str, key: str, prefix: str):
         """Test that parse_segment_name() correctly parses prefix-key segment names."""
-        assert parse_segment_name(f"{prefix}{delimiter}{key}") == SegmentName(
+        assert SegmentName.from_string(f"{prefix}{delimiter}{key}") == SegmentName(
             prefix=prefix, key=key
         )
 
@@ -208,9 +209,9 @@ class TestParseSegmentName:
         "string",
         ["", "*V/", "51f9a0bc-7b3b-434f-bf4c-f7abaa015b8d"],
     )
-    def test_none(self, string: str) -> None:
+    def test_from_string_none(self, string: str) -> None:
         """Test that parse_segment_name() returns expected ValueError for bad input."""
-        assert parse_segment_name(string) is None
+        assert SegmentName.from_string(string) is None
 
 
 class TestExtractSegmentNameFromRecord:
@@ -267,3 +268,64 @@ class TestExtractSegmentNameFromRecord:
         )
 
         assert extract_segment_name_from_record(record) is None
+
+
+class TesttExtractSegmentNameFromRecordWithPlanInference:
+    """Test segment name extraction with plan inference."""
+
+    plan: Plan
+
+    @pytest.fixture(autouse=True)
+    def _setup(
+        self,
+        ncbi_genbank_factory: NCBIGenbankFactory,
+        ncbi_source_factory: NCBISourceFactory,
+    ):
+        """Set up a plan with two segments."""
+        self.factories = SimpleNamespace(
+            genbank=ncbi_genbank_factory,
+            source=ncbi_source_factory,
+        )
+
+        self.plan = Plan.new(
+            [
+                Segment.new(100, 0.01, SegmentName(prefix="RNA", key="A")),
+                Segment.new(200, 0.02, SegmentName(prefix="RNA", key="B")),
+            ]
+        )
+
+    def test_no_inference(
+        self,
+        ncbi_genbank_factory: NCBIGenbankFactory,
+        ncbi_source_factory: NCBISourceFactory,
+    ) -> None:
+        """Test that an easily parseable segment name is returned."""
+        record = ncbi_genbank_factory.build(
+            source=ncbi_source_factory.build(
+                mol_type=NCBISourceMolType.GENOMIC_RNA,
+                segment="A",
+            ),
+        )
+
+        assert extract_segment_name_from_record_with_plan(
+            record, self.plan
+        ) == SegmentName(prefix="RNA", key="A")
+
+    def test_no_delimiter(
+        self,
+        ncbi_genbank_factory: NCBIGenbankFactory,
+        ncbi_source_factory: NCBISourceFactory,
+    ) -> None:
+        """Test that a segment name can be inferred from the plan when no delimiter is
+        present.
+        """
+        record = ncbi_genbank_factory.build(
+            source=ncbi_source_factory.build(
+                mol_type=NCBISourceMolType.GENOMIC_RNA,
+                segment="RNAB",
+            ),
+        )
+
+        assert extract_segment_name_from_record_with_plan(
+            record, self.plan
+        ) == SegmentName(prefix="RNA", key="B")


### PR DESCRIPTION
* Always try to get segment names from plans or parsing before using moltype.
* Parse segment names without delimiters using plans.
* Parse segment names without prefixes using plans.

## Linear Issues
* Resolves ECO-116.
* Resolves ECO-117.
