### PR TITLE
fix: delimiter-less segments don't `break create_otu()`

### DIFF
--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -202,6 +202,14 @@ def extract_segment_name_from_record(record: NCBIGenbank) -> SegmentName | None:
     if (name := SegmentName.from_string(record.source.segment)) is not None:
         return name
 
+    # Handles common cases without delimiters
+    for moltype_prefix in ["DNA", "RNA"]:
+        if record.source.segment.startswith(moltype_prefix):
+            return SegmentName(
+                prefix=record.moltype,
+                key=record.source.segment[3:].strip(),
+            )
+
     if SIMPLE_NAME_PATTERN.fullmatch(record.source.segment):
         return SegmentName(
             prefix=record.moltype,

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -178,14 +178,6 @@ class TestCreateOTU:
 
         assert otu.acronym == "FBNSV"
 
-    def test_otu_create_with_undelimited_segment_data_ok(self, precached_repo: Repo):
-        """Test that Genbank records with undelimited segment names can be used to create a new OTU."""
-        otu = create_otu(
-            precached_repo, 1520332, ["KJ704366", "KJ704367", "KJ704368"], acronym=""
-        )
-
-        assert otu
-
 
 class TestCreateOTUCommands:
     @pytest.mark.parametrize(

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -178,6 +178,14 @@ class TestCreateOTU:
 
         assert otu.acronym == "FBNSV"
 
+    def test_otu_create_with_undelimited_segment_data_ok(self, precached_repo: Repo):
+        """Test that Genbank records with undelimited segment names can be used to create a new OTU."""
+        otu = create_otu(
+            precached_repo, 1520332, ["KJ704366", "KJ704367", "KJ704368"], acronym=""
+        )
+
+        assert otu
+
 
 class TestCreateOTUCommands:
     @pytest.mark.parametrize(

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -248,6 +248,37 @@ class TestExtractSegmentNameFromRecord:
             prefix=suffix, key=key
         )
 
+    @pytest.mark.parametrize("key", ["1", "A", "U3"])
+    @pytest.mark.parametrize(
+        "mol_type", [NCBISourceMolType.GENOMIC_RNA, NCBISourceMolType.GENOMIC_DNA]
+    )
+    def test_no_delimiter_ok(
+        self,
+        key: str,
+        mol_type: NCBISourceMolType,
+        ncbi_genbank_factory: NCBIGenbankFactory,
+        ncbi_source_factory: NCBISourceFactory,
+    ):
+        """Test that extract_segment_name_from_record() can handle undelimited segment names."""
+        match mol_type:
+            case NCBISourceMolType.GENOMIC_DNA:
+                prefix = "DNA"
+            case NCBISourceMolType.GENOMIC_RNA:
+                prefix = "RNA"
+            case _:
+                raise ValueError(f"{mol_type} may not be a valid NCBISourceMolType.")
+
+        record = ncbi_genbank_factory.build(
+            source=ncbi_source_factory.build(
+                mol_type=mol_type,
+                segment=prefix + key,
+            ),
+        )
+
+        assert extract_segment_name_from_record(record) == SegmentName(
+            prefix=prefix, key=key
+        )
+
     @pytest.mark.parametrize("key", ["", "V#", "51f9a0bc-7b3b-434f-bf4c-f7abaa015b8d"])
     @pytest.mark.parametrize(
         "mol_type", [NCBISourceMolType.GENOMIC_RNA, NCBISourceMolType.GENOMIC_DNA]


### PR DESCRIPTION
* Parse segment names without delimiters using plan when creating a new OTU