### PR TITLE
fix: missing `as_json` arg in `otu_get`

### DIFF
--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -103,7 +103,7 @@ def otu_create(
     help="Output in JSON form",
 )
 @pass_repo
-def otu_get(repo: Repo, identifier: str) -> None:
+def otu_get(repo: Repo, identifier: str, as_json: bool) -> None:
     """Get an OTU by its unique ID or taxonomy ID."""
     try:
         identifier = int(identifier)

--- a/tests/cli/test_print_commands.py
+++ b/tests/cli/test_print_commands.py
@@ -25,3 +25,13 @@ class TestPrintCommands:
             )
 
             assert result.exit_code == 0
+
+    def test_otu_get_json_ok(self, scratch_repo):
+        for otu_ in scratch_repo.iter_otus():
+            result = runner.invoke(
+                otu_command_group,
+                ["--path", str(scratch_repo.path)]
+                + ["get", str(otu_.id), "--json"],
+            )
+
+            assert result.exit_code == 0

--- a/tests/cli/test_print_commands.py
+++ b/tests/cli/test_print_commands.py
@@ -30,8 +30,7 @@ class TestPrintCommands:
         for otu_ in scratch_repo.iter_otus():
             result = runner.invoke(
                 otu_command_group,
-                ["--path", str(scratch_repo.path)]
-                + ["get", str(otu_.id), "--json"],
+                ["--path", str(scratch_repo.path)] + ["get", str(otu_.id), "--json"],
             )
 
             assert result.exit_code == 0

--- a/tests/cli/test_print_commands.py
+++ b/tests/cli/test_print_commands.py
@@ -1,0 +1,27 @@
+from click.testing import CliRunner
+
+from ref_builder.cli.otu import otu as otu_command_group
+
+
+runner = CliRunner()
+
+
+class TestPrintCommands:
+    """Test otu console printing commands."""
+
+    def test_otu_list(self, scratch_repo):
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(scratch_repo.path)] + ["list"],
+        )
+
+        assert result.exit_code == 0
+
+    def test_otu_get_ok(self, scratch_repo):
+        for otu_ in scratch_repo.iter_otus():
+            result = runner.invoke(
+                otu_command_group,
+                ["--path", str(scratch_repo.path)] + ["get", str(otu_.id)],
+            )
+
+            assert result.exit_code == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,10 +141,6 @@ def scratch_repo(tmp_path: Path, scratch_event_store_data: dict[str, dict]) -> R
         with open(src_path / filename, "wb") as f:
             f.write(orjson.dumps(scratch_event_store_data[filename]))
 
-    head = int(max(scratch_event_store_data.keys()).split(".json")[0])
-    with open(path / "head", "w") as f:
-        f.write(str(head))
-
     (path / ".cache").mkdir(parents=True)
 
     return Repo(path)
@@ -219,6 +215,8 @@ def scratch_event_store_data(
             scratch_src[event_file_path.name] = orjson.loads(f.read())
 
     pytestconfig.cache.set("scratch_src", scratch_src)
+
+    return scratch_src
 
 
 class OTUContents(BaseModel):


### PR DESCRIPTION
* fix `scratch_event_store_data` return bug
* add CLI tests for `ref-builder otu list` and `ref-builder otu get`