### PR TITLE
fix `RepoOTU._sequences_by_id` bugs

### DIFF
--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -269,14 +269,22 @@ class RepoOTU(BaseModel):
 
     def delete_isolate(self, isolate_id: UUID4) -> None:
         """Remove an isolate from the OTU."""
-        self._isolates_by_id.pop(isolate_id)
+        if self._isolates_by_id.get(isolate_id) is None:
+            raise ValueError(f"Isolate {isolate_id} does not exist")
 
         for isolate in self.isolates:
             if isolate.id == isolate_id:
-                for sequence in isolate.sequences:
-                    self._sequences_by_id.pop(sequence.id)
+                for sequence_id in isolate.sequence_ids:
+                    if self.get_sequence_by_id(sequence_id) is None:
+                        raise ValueError(
+                            f"Sequence {sequence_id} not found in the sequence list"
+                        )
+                    self.delete_sequence(sequence_id)
 
                 self.isolates.remove(isolate)
+
+                self._isolates_by_id.pop(isolate_id)
+
                 break
 
     def delete_sequence(self, sequence_id: UUID4) -> None:

--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -257,6 +257,9 @@ class RepoOTU(BaseModel):
         self.isolates.append(isolate)
         self._isolates_by_id[isolate.id] = isolate
 
+        for sequence in isolate.sequences:
+            self.add_sequence(sequence)
+
     def add_sequence(self, sequence: RepoSequence) -> None:
         """Add a sequence to a given isolate."""
         self._sequences_by_id[sequence.id] = sequence

--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -111,15 +111,6 @@ class RepoIsolate(BaseModel):
         """Add a sequence to the isolate."""
         self.sequences.append(sequence)
 
-    def replace_sequence(
-        self,
-        sequence: RepoSequence,
-        replaced_sequence_id: UUID,
-    ) -> None:
-        """Replace a sequence with the given ID with a new sequence."""
-        self.add_sequence(sequence)
-        self.delete_sequence(replaced_sequence_id)
-
     def delete_sequence(self, sequence_id: UUID) -> None:
         """Delete a sequence from a given isolate."""
         sequence = self.get_sequence_by_id(sequence_id)
@@ -357,12 +348,3 @@ class RepoOTU(BaseModel):
     def unlink_sequence(self, isolate_id: UUID4, sequence_id: UUID4) -> None:
         """Unlink the given sequence from the given isolate. Used only during rehydration."""
         self.get_isolate(isolate_id).delete_sequence(sequence_id)
-
-    def replace_sequence(
-        self,
-        sequence: RepoSequence,
-        isolate_id: UUID4,
-        replaced_sequence_id: UUID4,
-    ) -> None:
-        """Replace a sequence with the given ID with a new sequence."""
-        self.get_isolate(isolate_id).replace_sequence(sequence, replaced_sequence_id)

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -295,6 +295,15 @@ class IsolateFactory(ModelFactory[IsolateBase]):
             for accession in cls.__faker__.accessions(sequence_count)
         ]
 
+    @staticmethod
+    def build_on_plan(plan: Plan):
+        """Take a plan and return a matching isolate."""
+        return IsolateFactory.build(
+            sequences=[
+                SequenceFactory.build(segment=segment.id) for segment in plan.segments
+            ]
+        )
+
 
 class OTUFactory(ModelFactory[OTUBase]):
     """OTU Factory with quasi-realistic data."""

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -106,6 +106,45 @@ class TestOTU:
         assert otu.get_isolate(isolate_id) is not None
         assert otu.get_sequence_by_id(sequence_id) is not None
 
+    def test_check_get_sequence_by_id_integrity(self, scratch_repo: Repo):
+        """Test that RepoOTU.get_sequence() can retrieve every sequence ID
+        within each constituent isolate from its own private index.
+        """
+
+        otu_ = RepoOTU(**OTUFactory.build().model_dump())
+
+        for i in range(10):
+            isolate = RepoIsolate(
+                **IsolateFactory.build_on_plan(otu_.plan).model_dump()
+            )
+            otu_.add_isolate(isolate)
+
+        sequence_ids_in_isolates = {
+            sequence.id for isolate in otu_.isolates for sequence in isolate.sequences
+        }
+
+        for sequence_id in sequence_ids_in_isolates:
+            assert otu_.get_sequence_by_id(sequence_id) is not None
+
+    def test_check_get_sequence_by_accession_integrity(self, scratch_repo: Repo):
+        """Test that RepoOTU.get_sequence() can retrieve every accession
+        within each constituent isolate.
+        """
+
+        otu_ = RepoOTU(**OTUFactory.build().model_dump())
+
+        for i in range(10):
+            isolate = RepoIsolate(
+                **IsolateFactory.build_on_plan(otu_.plan).model_dump()
+            )
+            otu_.add_isolate(isolate)
+
+        for isolate in otu_.isolates:
+            for sequence in isolate.sequences:
+                assert (
+                    otu_.get_sequence_by_accession(sequence.accession.key) == sequence
+                )
+
     def test_otu_delete_isolate(self):
         """Test that RepoOTU.delete_isolate() does not affect other isolates."""
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -7,6 +7,7 @@ from ref_builder.plan import Plan, Segment
 from ref_builder.repo import Repo
 from ref_builder.resources import RepoIsolate, RepoOTU
 from ref_builder.utils import IsolateName, IsolateNameType
+from tests.fixtures.factories import IsolateFactory, OTUFactory
 
 
 class TestSequence:
@@ -104,3 +105,28 @@ class TestOTU:
 
         assert otu.get_isolate(isolate_id) is not None
         assert otu.get_sequence_by_id(sequence_id) is not None
+
+    def test_otu_delete_isolate(self):
+        """Test that RepoOTU.delete_isolate() does not affect other isolates."""
+
+        otu_before = RepoOTU(**OTUFactory.build().model_dump())
+
+        for i in range(10):
+            isolate = RepoIsolate(
+                **IsolateFactory.build_on_plan(otu_before.plan).model_dump()
+            )
+            otu_before.add_isolate(isolate)
+
+        initial_isolate_ids = [isolate.id for isolate in otu_before.isolates]
+
+        deleted_id = initial_isolate_ids[3]
+
+        otu_after = otu_before.model_copy()
+
+        otu_after.delete_isolate(deleted_id)
+
+        assert otu_after.get_isolate(deleted_id) is None
+
+        for i in range(10):
+            extant_id = initial_isolate_ids[i + 3]
+            assert otu_after.get_isolate(extant_id) == otu_before.get_isolate(extant_id)


### PR DESCRIPTION
Addresses a bug where `RepoOTU.add_isolate()` does not add new sequences to `._sequences_by_id`, thereby causing a `KeyError` during `RepoOTU.delete_isolate()`.

* fix: ensure `RepoOTU.add_isolate()` adds the new sequence IDs to its private index
* add tests ensuring RepoIsolate sequences are accounted for in RepoOTU private index
* refactor: raise specific `ValueError` in `RepoOTU.delete_isolate()` if a key is not found 
* add test for `RepoOTU.delete_isolate()`
* delete unused `RepoIsolate.replace_sequence()`, `RepoOTU.replace_sequence()`

Resolves ECO-129