### PR TITLE
REF-3: Print new OTU after creation

### DIFF
--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -68,7 +68,7 @@ def otu_create(
 
     if taxid:
         try:
-            create_otu_with_taxid(
+            otu_ = create_otu_with_taxid(
                 repo,
                 taxid,
                 accessions_,
@@ -81,7 +81,7 @@ def otu_create(
 
     else:
         try:
-            create_otu_without_taxid(
+            otu_ = create_otu_without_taxid(
                 repo,
                 accessions_,
                 acronym=acronym,
@@ -90,6 +90,12 @@ def otu_create(
         except ValueError as e:
             click.echo(e, err=True)
             sys.exit(1)
+
+    if otu_ is None:
+        click.echo("OTU was not created correctly.", err=True)
+        sys.exit(1)
+
+    print_otu(otu_)
 
 
 @otu.command(name="get")

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -304,9 +304,7 @@ class Repo:
         """Create an OTU."""
         if (otu_id := self.get_otu_id_by_taxid(taxid)) is not None:
             otu = self.get_otu(otu_id)
-            raise ValueError(
-                f"OTU already exists as {otu}",
-            )
+            raise ValueError(f"OTU already exists as {otu.id}")
 
         if self._index.get_id_by_name(name):
             raise ValueError(f"An OTU with the name '{name}' already exists")

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -75,26 +75,6 @@ class TestCreateOTU:
         assert otu_.accessions == set(accessions)
         assert otu_.representative_isolate == otu_.isolates[0].id
 
-    def test_duplicate_accessions(self, precached_repo: Repo):
-        """Test that an error is raised when duplicate accessions are provided."""
-        runner = CliRunner()
-
-        result = runner.invoke(
-            otu,
-            [
-                "--path",
-                str(precached_repo.path),
-                "create",
-                "--taxid",
-                str(1169032),
-                "MK431779",
-                "MK431779",
-            ],
-        )
-
-        assert result.exit_code == 2
-        assert "Duplicate accessions are not allowed." in result.output
-
     def test_empty_repo(
         self,
         precached_repo: Repo,
@@ -288,6 +268,26 @@ class TestCreateOTUCommands:
 
         assert len(otus) == 1
         assert otus[0].acronym == "CabLCJV"
+
+    def test_duplicate_accessions(self, precached_repo: Repo):
+        """Test that an error is raised when duplicate accessions are provided."""
+        runner = CliRunner()
+
+        result = runner.invoke(
+            otu_command_group,
+            [
+                "--path",
+                str(precached_repo.path),
+                "create",
+                "--taxid",
+                str(1169032),
+                "MK431779",
+                "MK431779",
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "Duplicate accessions are not allowed." in result.output
 
 
 class TestAddIsolate:


### PR DESCRIPTION
* refactor `RepoOTU.create_otu()`: log the OTU ID of a conflicting OTU, rather than the entire `RepoOTU` contents
* check console output in `TestCreateOTUCommands.test_ok()`
* move `TestCreateOTUCommands.test_duplicate_accessions()`