### PR TITLE
fix: `Index.prune()` bug

### DIFF
--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -429,11 +429,10 @@ class Index:
         the repository.
 
         :param event_id: the event ID to rollback to
-
         """
         self.con.execute(
             """
-            DELETE FROM events WHERE at_event > ?
+            DELETE FROM events WHERE event_id > ?
             """,
             (event_id,),
         )

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -808,6 +808,8 @@ class Repo:
 
         self._event_store.prune(head_id)
 
+        head_path.unlink(missing_ok=True)
+
     def _write_event(self, cls: type[Event], data: EventData, query: EventQuery):
         """Write an event to the repository."""
         if self._transaction is None:


### PR DESCRIPTION
* rewrite query in `Index.prune()` to target the correct `events` table column, `event_id`
* `Repo._prune()` removes `head` file once the pruning operation is complete