### PR TITLE
fix: segment extraction with monopartite plan `AttributeError`

### DIFF
--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -236,30 +236,26 @@ def extract_segment_name_from_record_with_plan(
     if (segment_name := SegmentName.from_string(record.source.segment)) is not None:
         return segment_name
 
-    if plan.monopartite:
-        return None
+    if not plan.monopartite:
+        try:
+            plan_keys_and_prefixes = {
+                segment.name.key: segment.name.prefix for segment in plan.segments
+            }
+        except AttributeError:
+            raise ValueError("Multipartite plan contains unnamed segments")
 
-    try:
-        plan_keys_and_prefixes = {
-            segment.name.key: segment.name.prefix
-            for segment in plan.segments
-            if segment.name is not None
-        }
-    except AttributeError:
-        raise ValueError("Malformed plan")
+        # Handle no delimiter.
+        for prefix in plan_keys_and_prefixes.values():
+            if record.source.segment.casefold().startswith(prefix.casefold()):
+                return SegmentName(
+                    prefix=prefix, key=record.source.segment[len(prefix) :].strip()
+                )
 
-    # Handle no delimiter.
-    for prefix in plan_keys_and_prefixes.values():
-        if record.source.segment.casefold().startswith(prefix.casefold()):
+        # Handle no prefix.
+        with suppress(KeyError):
             return SegmentName(
-                prefix=prefix, key=record.source.segment[len(prefix) :].strip()
+                prefix=plan_keys_and_prefixes[record.source.segment],
+                key=record.source.segment,
             )
-
-    # Handle no prefix.
-    with suppress(KeyError):
-        return SegmentName(
-            prefix=plan_keys_and_prefixes[record.source.segment],
-            key=record.source.segment,
-        )
 
     return None

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -236,9 +236,17 @@ def extract_segment_name_from_record_with_plan(
     if (segment_name := SegmentName.from_string(record.source.segment)) is not None:
         return segment_name
 
-    plan_keys_and_prefixes = {
-        segment.name.key: segment.name.prefix for segment in plan.segments
-    }
+    if plan.monopartite:
+        return None
+
+    try:
+        plan_keys_and_prefixes = {
+            segment.name.key: segment.name.prefix
+            for segment in plan.segments
+            if segment.name is not None
+        }
+    except AttributeError:
+        raise ValueError("Malformed plan")
 
     # Handle no delimiter.
     for prefix in plan_keys_and_prefixes.values():


### PR DESCRIPTION
* if plan given to `extract_segment_name_from_record_with_plan()` is monopartite, return `None` rather than attempting to build a `plan_keys_and_prefixes` table