### PR TITLE
fix: `ref-builder isolate create [ACCESSIONS]`

### DIFF
--- a/ref_builder/cli/isolate.py
+++ b/ref_builder/cli/isolate.py
@@ -65,29 +65,28 @@ def isolate_create(
         sys.exit(1)
 
     if unnamed:
-        with repo.use_transaction():
-            add_unnamed_isolate(
-                repo,
-                otu_,
-                accessions_,
-                ignore_cache=ignore_cache,
-            )
-        sys.exit(1)
+        add_unnamed_isolate(
+            repo,
+            otu_,
+            accessions_,
+            ignore_cache=ignore_cache,
+        )
+
+        sys.exit(0)
 
     if name is not None:
         isolate_name_type, isolate_name_value = name
         isolate_name_ = IsolateName(type=isolate_name_type, value=isolate_name_value)
 
         try:
-            with repo.use_transaction():
-                add_and_name_isolate(
-                    repo,
-                    otu_,
-                    accessions_,
-                    ignore_cache=ignore_cache,
-                    isolate_name=isolate_name_,
-                )
-            sys.exit(1)
+            add_and_name_isolate(
+                repo,
+                otu_,
+                accessions_,
+                ignore_cache=ignore_cache,
+                isolate_name=isolate_name_,
+            )
+            sys.exit(0)
 
         except RefSeqConflictError as e:
             click.echo(
@@ -97,13 +96,12 @@ def isolate_create(
             sys.exit(1)
 
     try:
-        with repo.use_transaction():
-            add_genbank_isolate(
-                repo,
-                otu_,
-                accessions_,
-                ignore_cache=ignore_cache,
-            )
+        add_genbank_isolate(
+            repo,
+            otu_,
+            accessions_,
+            ignore_cache=ignore_cache,
+        )
     except RefSeqConflictError as e:
         click.echo(
             f"{e.isolate_name} already exists, but RefSeq items may be promotable,",

--- a/tests/cli/test_isolate_commands.py
+++ b/tests/cli/test_isolate_commands.py
@@ -1,0 +1,108 @@
+from click.testing import CliRunner
+
+from ref_builder.cli.otu import otu as otu_command_group
+from ref_builder.cli.isolate import isolate as isolate_command_group
+
+runner = CliRunner()
+
+
+class TestIsolateCreateCommand:
+    """Test `ref-builder isolate create`` works as expected."""
+
+    def test_ok(self, precached_repo):
+        """Test basic command functionality."""
+        path_option_list = ["--path", str(precached_repo.path)]
+
+        taxid = 1169032
+
+        rep_isolate_accessions = ["MF062136", "MF062137", "MF062138"]
+
+        result = runner.invoke(
+            otu_command_group,
+            path_option_list
+            + ["create", "--taxid", str(taxid)]
+            + rep_isolate_accessions,
+        )
+
+        assert result.exit_code == 0
+
+        second_isolate_accessions = ["MF062125", "MF062126", "MF062127"]
+
+        result = runner.invoke(
+            isolate_command_group,
+            path_option_list
+            + ["create", "--taxid", str(taxid)]
+            + second_isolate_accessions,
+        )
+
+        assert result.exit_code == 0
+
+        assert "Isolate created" in result.output
+
+    def test_overwrite_name_option_ok(self, precached_repo):
+        """Test that --name option exits smoothly"""
+        path_option_list = ["--path", str(precached_repo.path)]
+
+        taxid = 345184
+
+        result = runner.invoke(
+            otu_command_group,
+            path_option_list
+            + ["create", "--taxid", str(taxid)]
+            + ["DQ178610", "DQ178611"],
+        )
+
+        assert result.exit_code == 0
+
+        result = runner.invoke(
+            isolate_command_group,
+            path_option_list
+            + ["create", "--taxid", str(taxid)]
+            + ["--name", "isolate", "dummy"]
+            + ["DQ178613", "DQ178614"],
+        )
+
+        assert result.exit_code == 0
+
+        assert "Isolate created" and "Isolate dummy" in result.output
+
+    def test_unnamed_option_ok(self, precached_repo):
+        """Test that --unnamed option exits smoothly."""
+        path_option_list = ["--path", str(precached_repo.path)]
+
+        taxid = 345184
+
+        result = runner.invoke(
+            otu_command_group,
+            path_option_list
+            + ["create", "--taxid", str(taxid)]
+            + ["DQ178610", "DQ178611"],
+        )
+
+        assert result.exit_code == 0
+
+        result = runner.invoke(
+            isolate_command_group,
+            path_option_list
+            + ["create", "--taxid", str(taxid)]
+            + ["--unnamed"]
+            + ["DQ178613", "DQ178614"],
+        )
+
+        assert result.exit_code == 0
+
+        assert "Isolate created" and "Unnamed" in result.output
+
+    def test_duplicate_accessions_error(self, scratch_repo):
+        """Test that an error is raised when duplicate accessions are provided."""
+
+        result = runner.invoke(
+            isolate_command_group,
+            ["--path", str(scratch_repo.path)]
+            + ["create", "--taxid", str(345184)]
+            + ["DQ178610", "DQ178610"],
+        )
+
+        assert result.exit_code == 2
+
+        assert "Duplicate accessions are not allowed." in result.output

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -391,7 +391,7 @@ class TestAddIsolate:
 
         assert otu.accessions == set(isolate_1_accessions)
 
-        with precached_repo.lock(), precached_repo.use_transaction():
+        with precached_repo.lock():
             isolate = add_unnamed_isolate(precached_repo, otu, isolate_2_accessions)
 
         otu_after = precached_repo.get_otu_by_taxid(345184)
@@ -415,12 +415,13 @@ class TestAddIsolate:
 
         assert otu.accessions == set(isolate_1_accessions)
 
-        isolate = add_and_name_isolate(
-            precached_repo,
-            otu,
-            isolate_2_accessions,
-            isolate_name=IsolateName(type=IsolateNameType.ISOLATE, value="dummy"),
-        )
+        with precached_repo.lock():
+            isolate = add_and_name_isolate(
+                precached_repo,
+                otu,
+                isolate_2_accessions,
+                isolate_name=IsolateName(type=IsolateNameType.ISOLATE, value="dummy"),
+            )
 
         otu_after = precached_repo.get_otu_by_taxid(345184)
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -9,7 +9,6 @@ from syrupy.filters import props
 
 from ref_builder.console import console, print_otu
 from ref_builder.cli.otu import otu as otu_command_group
-from ref_builder.cli.isolate import isolate_create
 from ref_builder.otu.create import create_otu_with_taxid, create_otu_without_taxid
 from ref_builder.otu.isolate import (
     add_and_name_isolate,
@@ -331,21 +330,6 @@ class TestAddIsolate:
             "MF062126",
             "MF062127",
         }
-
-    def test_duplicate_accessions(self, precached_repo: Repo):
-        """Test that an error is raised when duplicate accessions are provided."""
-        runner = CliRunner()
-        result = runner.invoke(
-            isolate_create,
-            [
-                "345184",
-                "DQ178610",
-                "DQ178610",
-            ],
-        )
-
-        assert result.exit_code == 2
-        assert "Duplicate accessions are not allowed." in result.output
 
     def test_genbank(self, precached_repo: Repo):
         """Test that add_genbank_isolate() adds an isolate with a correctly parsed


### PR DESCRIPTION
This PR restores lost `ref-builder isolate create` command functionality and updates test coverage to match.

* add `test_isolate_commands::TestIsolateCreateCommand` to check `isolate create` commands run as expected
* fix: midway created isolate aborts the transaction
* fix: remove overly nested transactions from CLI code
* fix: successful `ref-builder create isolate` no longer exits with exit code 1