### PR TITLE
fix: `otu exclude-accessions`, `otu allow-accessions`

### DIFF
--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -184,7 +184,7 @@ def otu_promote_accessions(repo: Repo, taxid: int, ignore_cache: bool) -> None:
 
 
 @otu.command(name="exclude-accessions")  # type: ignore
-@click.argument("TAXID", type=int)
+@click.argument("IDENTIFIER", type=str)
 @click.argument(
     "accessions_",
     metavar="ACCESSIONS",
@@ -195,25 +195,32 @@ def otu_promote_accessions(repo: Repo, taxid: int, ignore_cache: bool) -> None:
 @pass_repo
 def otu_exclude_accessions(
     repo: Repo,
+    identifier: str,
     accessions_: list[str],
-    taxid: int,
 ) -> None:
     """Exclude the given accessions from this OTU.
 
     Any duplicate accessions will be ignored. Only one exclusion per unique accession
     will be made.
+
+    IDENTIFIER is a taxonomy ID or unique OTU ID (>8 characters)
     """
-    otu_ = repo.get_otu_by_taxid(taxid)
+    try:
+        otu_id = UUID(identifier)
+    except ValueError:
+        otu_id = _get_otu_id_from_other_identifier(repo, identifier)
+
+    otu_ = repo.get_otu(otu_id)
 
     if otu_ is None:
-        click.echo(f"OTU {taxid} not found.", err=True)
+        click.echo("OTU not found.", err=True)
         sys.exit(1)
 
     exclude_accessions_from_otu(repo, otu_, accessions_)
 
 
 @otu.command(name="allow-accessions")  # type: ignore
-@click.argument("TAXID", type=int)
+@click.argument("IDENTIFIER", type=str)
 @click.argument(
     "accessions_",
     metavar="ACCESSIONS",
@@ -224,18 +231,25 @@ def otu_exclude_accessions(
 @pass_repo
 def otu_allow_accessions(
     repo: Repo,
+    identifier: str,
     accessions_: list[str],
-    taxid: int,
 ) -> None:
     """Allow the given excluded accessions back into the OTU.
 
     Any duplicate accessions will be ignored. Only one exclusion per unique accession
     will be made.
+
+    IDENTIFIER is a taxonomy ID or unique OTU ID (>8 characters)
     """
-    otu_ = repo.get_otu_by_taxid(taxid)
+    try:
+        otu_id = UUID(identifier)
+    except ValueError:
+        otu_id = _get_otu_id_from_other_identifier(repo, identifier)
+
+    otu_ = repo.get_otu(otu_id)
 
     if otu_ is None:
-        click.echo(f"OTU {taxid} not found.", err=True)
+        click.echo("OTU not found.", err=True)
         sys.exit(1)
 
     allow_accessions_into_otu(repo, otu_, set(accessions_))

--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -192,7 +192,6 @@ def otu_promote_accessions(repo: Repo, taxid: int, ignore_cache: bool) -> None:
     type=str,
     required=True,
 )
-@ignore_cache_option
 @pass_repo
 def otu_exclude_accessions(
     repo: Repo,
@@ -222,7 +221,6 @@ def otu_exclude_accessions(
     type=str,
     required=True,
 )
-@ignore_cache_option
 @pass_repo
 def otu_allow_accessions(
     repo: Repo,

--- a/ref_builder/otu/modify.py
+++ b/ref_builder/otu/modify.py
@@ -28,8 +28,25 @@ def exclude_accessions_from_otu(
     accessions: Collection[str],
 ) -> None:
     """Exclude accessions from future addition to an OTU."""
+    original_excluded_accessions = otu.excluded_accessions.copy()
+
     with repo.use_transaction():
-        repo.exclude_accessions(otu_id=otu.id, accessions=accessions)
+        excluded_accessions = repo.exclude_accessions(
+            otu_id=otu.id, accessions=accessions
+        )
+
+    if excluded_accessions != original_excluded_accessions:
+        logger.info(
+            "Updated excluded accession list.",
+            otu_id=str(otu.id),
+            excluded_accessions=sorted(excluded_accessions),
+        )
+
+    if excluded_accessions == original_excluded_accessions:
+        logger.info(
+            "Excluded accession list already up to date.",
+            excluded_accessions=excluded_accessions,
+        )
 
 
 def allow_accessions_into_otu(
@@ -41,8 +58,25 @@ def allow_accessions_into_otu(
 
     This reverses the effect of exclude_accessions_from_otu.
     """
+    original_excluded_accessions = otu.excluded_accessions.copy()
+
     with repo.use_transaction():
-        repo.allow_accessions(otu_id=otu.id, accessions=accessions)
+        excluded_accessions = repo.allow_accessions(
+            otu_id=otu.id, accessions=accessions
+        )
+
+    if excluded_accessions != original_excluded_accessions:
+        logger.info(
+            "Updated excluded accession list.",
+            otu_id=str(otu.id),
+            excluded_accessions=sorted(excluded_accessions),
+        )
+
+    if excluded_accessions == original_excluded_accessions:
+        logger.info(
+            "Excluded accession list already up to date.",
+            excluded_accessions=excluded_accessions,
+        )
 
 
 def delete_isolate_from_otu(repo: Repo, otu: RepoOTU, isolate_id: UUID) -> None:

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -716,7 +716,6 @@ class Repo:
                 "Removed accessions from excluded accession list.",
                 taxid=otu.taxid,
                 otu_id=str(otu.id),
-                excluded_accessions=sorted(otu.excluded_accessions),
                 new_excluded_accessions=sorted(allowable_accessions),
             )
 

--- a/tests/cli/__snapshots__/test_otu_commands.ambr
+++ b/tests/cli/__snapshots__/test_otu_commands.ambr
@@ -1,5 +1,31 @@
 # serializer version: 1
-# name: TestCreateOTU.test_empty_repo
+# name: TestCreateOTUCommands.test_with_taxid_ok[1278205-accessions0]
+  dict({
+    'acronym': '',
+    'excluded_accessions': set({
+      'JX263426',
+    }),
+    'legacy_id': None,
+    'molecule': dict({
+      'strandedness': 'single',
+      'topology': 'linear',
+      'type': 'RNA',
+    }),
+    'name': 'Dahlia latent viroid',
+    'plan': dict({
+      'segments': list([
+        dict({
+          'length': 342,
+          'length_tolerance': 0.03,
+          'name': None,
+          'rule': 'required',
+        }),
+      ]),
+    }),
+    'taxid': 1278205,
+  })
+# ---
+# name: TestCreateOTUCommands.test_with_taxid_ok[345184-accessions1]
   dict({
     'acronym': '',
     'excluded_accessions': set({

--- a/tests/cli/test_otu_commands.py
+++ b/tests/cli/test_otu_commands.py
@@ -1,0 +1,115 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from syrupy import SnapshotAssertion
+from syrupy.filters import props
+
+from ref_builder.cli.otu import otu as otu_command_group
+from ref_builder.console import console, print_otu
+from ref_builder.repo import Repo
+
+
+runner = CliRunner()
+
+
+class TestCreateOTUCommands:
+    """Test the behaviour of ``ref-builder otu create``."""
+
+    @pytest.mark.parametrize(
+        ("taxid", "accessions"),
+        [(1278205, ["NC_020160"]), (345184, ["DQ178610", "DQ178611"])],
+    )
+    def test_with_taxid_ok(
+        self,
+        taxid: int,
+        accessions: list[str],
+        precached_repo: Repo,
+        snapshot: SnapshotAssertion,
+    ):
+        """Test that an OTU can be created with the --taxid option.
+
+        Also check resulting print_otu() console output.
+        """
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(precached_repo.path)]
+            + ["create", "--taxid", str(taxid)]
+            + accessions,
+        )
+
+        assert result.exit_code == 0
+
+        otus = list(Repo(precached_repo.path).iter_otus())
+
+        assert len(otus) == 1
+        assert otus[0].model_dump() == snapshot(
+            exclude=props("id", "isolates", "representative_isolate"),
+        )
+
+        with console.capture() as capture:
+            print_otu(otus[0])
+
+        assert capture.get() in result.output
+
+    @pytest.mark.parametrize(
+        ("taxid", "accessions"),
+        [(1278205, ["NC_020160"]), (345184, ["DQ178610", "DQ178611"])],
+    )
+    def test_without_taxid_ok(
+        self,
+        taxid: int,
+        accessions: list[str],
+        precached_repo: Repo,
+    ):
+        """Test that an OTU can be created without the --taxid option."""
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(precached_repo.path)] + ["create"] + accessions,
+        )
+
+        assert result.exit_code == 0
+
+        otus = list(Repo(precached_repo.path).iter_otus())
+
+        assert len(otus) == 1
+        assert otus[0].taxid == taxid
+
+    def test_acronym(self, precached_repo: Repo):
+        """Test that Athe --acronym option works as planned."""
+        acronym_ = "CabLCJV"
+
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(precached_repo.path)]
+            + [
+                "create",
+                "--taxid",
+                str(345184),
+                "--acronym",
+                acronym_,
+            ]
+            + ["DQ178610", "DQ178611"],
+        )
+
+        assert result.exit_code == 0
+
+        otus = list(Repo(precached_repo.path).iter_otus())
+
+        assert len(otus) == 1
+        assert otus[0].acronym == acronym_
+
+    def test_duplicate_accessions(self, precached_repo: Repo):
+        """Test that an error is raised when duplicate accessions are provided."""
+        runner = CliRunner()
+
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(precached_repo.path)]
+            + ["create", "--taxid", str(1169032)]
+            + ["MK431779", "MK431779"],
+        )
+
+        assert result.exit_code == 2
+        assert "Duplicate accessions are not allowed." in result.output

--- a/tests/cli/test_otu_commands.py
+++ b/tests/cli/test_otu_commands.py
@@ -1,5 +1,4 @@
-import subprocess
-from pathlib import Path
+from uuid import UUID
 
 import pytest
 from click.testing import CliRunner
@@ -9,7 +8,6 @@ from syrupy.filters import props
 from ref_builder.cli.otu import otu as otu_command_group
 from ref_builder.console import console, print_otu
 from ref_builder.repo import Repo
-
 
 runner = CliRunner()
 
@@ -113,3 +111,23 @@ class TestCreateOTUCommands:
 
         assert result.exit_code == 2
         assert "Duplicate accessions are not allowed." in result.output
+
+
+class TestExcludeAccessionsCommand:
+    """Test that ``ref-builder otu exclude-accessions`` behaves as expected."""
+
+    def test_excludable_ok(self, scratch_repo):
+        """Test that command lists out new excluded accessions"""
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(scratch_repo.path)]
+            + ["exclude-accessions", str(345184)]
+            + ["DQ178608", "DQ178609"],
+        )
+
+        assert result.exit_code == 0
+
+        assert "Added accessions to excluded accession list" in result.output
+
+        assert "['DQ178608', 'DQ178609']" in result.output
+        

--- a/tests/cli/test_otu_commands.py
+++ b/tests/cli/test_otu_commands.py
@@ -131,6 +131,30 @@ class TestExcludeAccessionsCommand:
 
         assert "['DQ178608', 'DQ178609']" in result.output
 
+    def test_redundant_ok(self, scratch_repo):
+        """Test that the command informs the user when excluded accessions are already up to date."""
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(scratch_repo.path)]
+            + ["exclude-accessions", str(345184)]
+            + ["DQ178608", "DQ178609"],
+        )
+
+        assert result.exit_code == 0
+
+        assert "['DQ178608', 'DQ178609']" in result.output
+
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(scratch_repo.path)]
+            + ["exclude-accessions", str(345184)]
+            + ["DQ178608", "DQ178609"],
+        )
+
+        assert result.exit_code == 0
+
+        assert "Excluded accession list already up to date" in result.output
+
 
 class TestAllowAccessionsCommand:
     """Test that ``ref-builder otu allow-accessions`` behaves as expected."""

--- a/tests/cli/test_otu_commands.py
+++ b/tests/cli/test_otu_commands.py
@@ -130,4 +130,50 @@ class TestExcludeAccessionsCommand:
         assert "Added accessions to excluded accession list" in result.output
 
         assert "['DQ178608', 'DQ178609']" in result.output
-        
+
+
+class TestAllowAccessionsCommand:
+    """Test that ``ref-builder otu allow-accessions`` behaves as expected."""
+
+    def test_allowable_ok(self, scratch_repo: Repo):
+        """Test that command lists out newly allowable accessions"""
+        taxid = 345184
+
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(scratch_repo.path)]
+            + ["exclude-accessions", str(taxid)]
+            + ["DQ178608", "DQ178609"],
+        )
+
+        assert result.exit_code == 0
+
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(scratch_repo.path)]
+            + ["allow-accessions", str(taxid)]
+            + ["DQ178608"],
+        )
+
+        assert result.exit_code == 0
+
+        assert "Removed accessions from excluded accession list" in result.output
+
+        assert "['DQ178608']" in result.output
+
+        assert "Updated excluded accession list" in result.output
+
+        assert "['DQ178609']" in result.output
+
+    def test_redundant_ok(self, scratch_repo: Repo):
+        """Test that the command informs the user when excluded accessions are already up to date."""
+        result = runner.invoke(
+            otu_command_group,
+            ["--path", str(scratch_repo.path)]
+            + ["allow-accessions", str(345184)]
+            + ["DQ178612", "DQ178613"],
+        )
+
+        assert result.exit_code == 0
+
+        assert "Excluded accession list already up to date" in result.output

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,6 +1,3 @@
-import subprocess
-from pathlib import Path
-
 import pytest
 from click.testing import CliRunner
 from syrupy import SnapshotAssertion
@@ -21,29 +18,6 @@ from ref_builder.otu.update import (
 from ref_builder.otu.utils import RefSeqConflictError
 from ref_builder.repo import Repo
 from ref_builder.utils import IsolateName, IsolateNameType
-
-
-def run_create_otu_command(
-    path: Path,
-    taxid: int,
-    accessions: list,
-    acronym: str = "",
-):
-    subprocess.run(
-        [
-            "ref-builder",
-            "otu",
-            "--path",
-            str(path),
-            "create",
-            *accessions,
-            "--taxid",
-            str(taxid),
-            "--acronym",
-            acronym,
-        ],
-        check=False,
-    )
 
 
 class TestCreateOTU:
@@ -193,107 +167,6 @@ class TestCreateOTU:
         otu = precached_repo.get_otu_by_taxid(expected_taxid)
 
         assert otu is not None
-
-
-class TestCreateOTUCommands:
-    @pytest.mark.parametrize(
-        ("taxid", "accessions"),
-        [(1278205, ["NC_020160"]), (345184, ["DQ178610", "DQ178611"])],
-    )
-    def test_ok(
-        self,
-        taxid: int,
-        accessions: list[str],
-        precached_repo: Repo,
-        snapshot: SnapshotAssertion,
-    ):
-        """Test that an OTU can be created using the command line interface.
-
-        Also check resulting print_otu() console output.
-        """
-        runner = CliRunner()
-
-        result = runner.invoke(
-            otu_command_group,
-            ["--path", str(precached_repo.path)]
-            + ["create", "--taxid", str(taxid)]
-            + accessions,
-        )
-
-        assert result.exit_code == 0
-
-        otus = list(Repo(precached_repo.path).iter_otus())
-
-        assert len(otus) == 1
-        assert otus[0].model_dump() == snapshot(
-            exclude=props("id", "isolates", "representative_isolate"),
-        )
-
-        with console.capture() as capture:
-            print_otu(otus[0])
-
-        assert capture.get() in result.output
-
-    @pytest.mark.parametrize(
-        "taxid, accessions",
-        [(1278205, ["NC_020160"]), (345184, ["DQ178610", "DQ178611"])],
-    )
-    def test_without_taxid_ok(
-        self,
-        taxid: int,
-        accessions: list[str],
-        precached_repo: Repo,
-    ):
-        subprocess.run(
-            [
-                "ref-builder",
-                "otu",
-                "--path",
-                str(precached_repo.path),
-                "create",
-                *accessions,
-            ],
-            check=False,
-        )
-
-        otus = list(Repo(precached_repo.path).iter_otus())
-
-        assert len(otus) == 1
-        assert otus[0].taxid == taxid
-
-    def test_acronym(self, precached_repo: Repo):
-        """Test if the --acronym option works as planned."""
-        run_create_otu_command(
-            taxid=345184,
-            accessions=["DQ178610", "DQ178611"],
-            path=precached_repo.path,
-            acronym="CabLCJV",
-        )
-
-        otus = list(Repo(precached_repo.path).iter_otus())
-
-        assert len(otus) == 1
-        assert otus[0].acronym == "CabLCJV"
-
-    def test_duplicate_accessions(self, precached_repo: Repo):
-        """Test that an error is raised when duplicate accessions are provided."""
-        runner = CliRunner()
-
-        result = runner.invoke(
-            otu_command_group,
-            [
-                "--path",
-                str(precached_repo.path),
-                "create",
-                "--taxid",
-                str(1169032),
-                "MK431779",
-                "MK431779",
-            ],
-        )
-
-        assert result.exit_code == 2
-        assert "Duplicate accessions are not allowed." in result.output
 
 
 class TestAddIsolate:


### PR DESCRIPTION
Restores lost CLI access to two commands.

* allow use of OTU id (full or partial) as identifier
* move `TestCreateOTUCommands` to `tests.cli.test_otu_commands`