### PR TITLE
feat: add `otu batch-update` convenience options

### DIFF
--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -143,16 +143,12 @@ def otu_list(repo: Repo) -> None:
 
 
 @otu.command(name="batch-update")
-@click.option(
-    "--precache",
-    is_flag=True,
-    help="Precache all NCBI Nucleotide records."
-)
+@click.option("--precache", is_flag=True, help="Precache all NCBI Nucleotide records.")
 @click.option(
     "--precache-batch-size",
     type=int,
     default=250,
-    help="Change precache batch size (default 250)."
+    help="Change precache batch size (default 250).",
 )
 @click.option(
     "--fetch-index-path",
@@ -161,7 +157,7 @@ def otu_list(repo: Repo) -> None:
         file_okay=True,
         path_type=Path,
     ),
-    help="Input a file path to a fetch index file."
+    help="Input a file path to a fetch index file.",
 )
 @ignore_cache_option
 @pass_repo

--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -145,6 +145,15 @@ def otu_list(repo: Repo) -> None:
 @otu.command(name="batch-update")
 @click.option("--fetch-batch-size", type=int, default=250)
 @click.option("--precache", is_flag=True)
+@click.option("--fetch-batch-size", type=int, default=250)
+@click.option(
+    "--fetch-index-path",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        path_type=Path,
+    ),
+)
 @ignore_cache_option
 @pass_repo
 def otu_batch_auto_update(
@@ -152,10 +161,12 @@ def otu_batch_auto_update(
     fetch_batch_size: int,
     precache: bool,
     ignore_cache: bool,
+    fetch_index_path: Path | None,
 ) -> None:
     """Update all OTUs with the latest data from NCBI."""
     batch_update_repo(
         repo,
+        fetch_index_path=fetch_index_path,
         chunk_size=fetch_batch_size,
         precache_records=precache,
         ignore_cache=ignore_cache,

--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -143,12 +143,18 @@ def otu_list(repo: Repo) -> None:
 
 
 @otu.command(name="batch-update")
+@click.option("--fetch-batch-size", type=int, default=250)
 @ignore_cache_option
 @pass_repo
-def otu_batch_auto_update(repo: Repo, ignore_cache: bool) -> None:
+def otu_batch_auto_update(
+    repo: Repo,
+    fetch_batch_size: int,
+    ignore_cache: bool,
+) -> None:
     """Update all OTUs with the latest data from NCBI."""
     batch_update_repo(
         repo,
+        chunk_size=fetch_batch_size,
         ignore_cache=ignore_cache,
     )
 

--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -143,9 +143,17 @@ def otu_list(repo: Repo) -> None:
 
 
 @otu.command(name="batch-update")
-@click.option("--fetch-batch-size", type=int, default=250)
-@click.option("--precache", is_flag=True)
-@click.option("--fetch-batch-size", type=int, default=250)
+@click.option(
+    "--precache",
+    is_flag=True,
+    help="Precache all NCBI Nucleotide records."
+)
+@click.option(
+    "--precache-batch-size",
+    type=int,
+    default=250,
+    help="Change precache batch size (default 250)."
+)
 @click.option(
     "--fetch-index-path",
     type=click.Path(
@@ -158,7 +166,7 @@ def otu_list(repo: Repo) -> None:
 @pass_repo
 def otu_batch_auto_update(
     repo: Repo,
-    fetch_batch_size: int,
+    precache_batch_size: int,
     precache: bool,
     ignore_cache: bool,
     fetch_index_path: Path | None,
@@ -167,7 +175,7 @@ def otu_batch_auto_update(
     batch_update_repo(
         repo,
         fetch_index_path=fetch_index_path,
-        chunk_size=fetch_batch_size,
+        chunk_size=precache_batch_size,
         precache_records=precache,
         ignore_cache=ignore_cache,
     )

--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -161,6 +161,7 @@ def otu_list(repo: Repo) -> None:
         file_okay=True,
         path_type=Path,
     ),
+    help="Input a file path to a fetch index file."
 )
 @ignore_cache_option
 @pass_repo

--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -144,17 +144,20 @@ def otu_list(repo: Repo) -> None:
 
 @otu.command(name="batch-update")
 @click.option("--fetch-batch-size", type=int, default=250)
+@click.option("--precache", is_flag=True)
 @ignore_cache_option
 @pass_repo
 def otu_batch_auto_update(
     repo: Repo,
     fetch_batch_size: int,
+    precache: bool,
     ignore_cache: bool,
 ) -> None:
     """Update all OTUs with the latest data from NCBI."""
     batch_update_repo(
         repo,
         chunk_size=fetch_batch_size,
+        precache_records=precache,
         ignore_cache=ignore_cache,
     )
 

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -77,9 +77,7 @@ def batch_update_repo(
     ignore_cache: bool = False,
 ):
     """Fetch new accessions for all OTUs in the repo and create isolates as possible."""
-    repo_logger = logger.bind(
-        path=str(repo.path), precache_records=precache_records
-    )
+    repo_logger = logger.bind(path=str(repo.path), precache_records=precache_records)
 
     repo_logger.info("Starting batch update...")
 
@@ -127,7 +125,8 @@ def batch_update_repo(
             return None
 
         logger.info(
-            "Checking new records against OTUs.", otu_count=len(taxid_new_accession_index)
+            "Checking new records against OTUs.",
+            otu_count=len(taxid_new_accession_index),
         )
 
         for taxid, accessions in taxid_new_accession_index.items():
@@ -154,7 +153,9 @@ def batch_update_repo(
         ncbi = NCBIClient(ignore_cache)
 
         for taxid, accessions in taxid_new_accession_index.items():
-            otu_id = repo.get_otu_id_by_taxid(taxid)
+            if (otu_id := repo.get_otu_id_by_taxid(taxid)) is None:
+                logger.debug("No corresponding OTU found in this repo", taxid=taxid)
+                continue
 
             otu_records = ncbi.fetch_genbank_records(accessions)
 
@@ -552,7 +553,8 @@ def _bin_refseq_records(
 
 
 def _cache_fetch_index(
-    fetch_index: dict[int, set[str]], cache_path: Path,
+    fetch_index: dict[int, set[str]],
+    cache_path: Path,
 ) -> Path | None:
     validated_fetch_index = BatchFetchIndex.model_validate(fetch_index)
 

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -151,16 +151,21 @@ def batch_update_repo(
             repo.get_otu(otu_id)
 
     else:
+        ncbi = NCBIClient(ignore_cache)
+
         for taxid, accessions in taxid_new_accession_index.items():
             otu_id = repo.get_otu_id_by_taxid(taxid)
 
-            update_otu_with_accessions(
-                repo,
-                otu=repo.get_otu(otu_id),
-                accessions=accessions
-            )
+            otu_records = ncbi.fetch_genbank_records(accessions)
 
-            repo.get_otu(otu_id)
+            if otu_records:
+                update_otu_with_records(
+                    repo,
+                    otu=repo.get_otu(otu_id),
+                    records=otu_records,
+                )
+
+                repo.get_otu(otu_id)
 
     repo_logger.info("Batch update complete.")
 

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -308,7 +308,7 @@ def update_isolate_from_records(
 def update_otu_with_accessions(
     repo: Repo,
     otu: RepoOTU,
-    accessions: list,
+    accessions: Collection[str],
     ignore_cache: bool = False,
 ) -> list[UUID]:
     """Take a list of accessions, filter for eligible accessions and

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -194,6 +194,34 @@ def batch_fetch_new_records(
     return {}
 
 
+def batch_file_new_records(
+    repo: Repo,
+    indexed_accessions: dict[int, set[str]],
+    indexed_records: dict[str, NCBIGenbank],
+):
+    logger.info("Checking new records against OTUs.", otu_count=len(indexed_accessions))
+
+    for taxid, accessions in indexed_accessions.items():
+        otu_records = [
+            record
+            for accession in accessions
+            if (record := indexed_records.get(accession)) is not None
+        ]
+
+        if not otu_records:
+            continue
+
+        otu_id = repo.get_otu_id_by_taxid(taxid)
+
+        update_otu_with_records(
+            repo,
+            otu=repo.get_otu(otu_id),
+            records=otu_records,
+        )
+
+        repo.get_otu(otu_id)
+
+
 def update_isolate_from_accessions(
     repo: Repo,
     otu: RepoOTU,

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -72,6 +72,7 @@ def auto_update_otu(
 def batch_update_repo(
     repo: Repo,
     chunk_size: int = RECORD_FETCH_CHUNK_SIZE,
+    fetch_index_path: Path | None = None,
     precache_records: bool = False,
     ignore_cache: bool = False,
 ):
@@ -82,9 +83,23 @@ def batch_update_repo(
 
     repo_logger.info("Starting batch update...")
 
-    taxid_new_accession_index = batch_fetch_new_accessions(
-        repo.iter_otus(), ignore_cache
-    )
+    if fetch_index_path is None:
+        taxid_new_accession_index = batch_fetch_new_accessions(
+            repo.iter_otus(), ignore_cache
+        )
+
+        fetch_index_cache_path = _cache_fetch_index(
+            taxid_new_accession_index, repo.path / ".cache"
+        )
+
+        repo_logger.info("Fetch index cached", fetch_index_path=fetch_index_cache_path)
+
+    else:
+        repo_logger.info(
+            "Loading fetch index...", fetch_index_path=str(fetch_index_path)
+        )
+
+        taxid_new_accession_index = _load_fetch_index(fetch_index_path)
 
     if not taxid_new_accession_index:
         logger.info("OTUs are up to date.")

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -193,6 +193,12 @@ def batch_fetch_new_records(
     ignore_cache: bool = False,
 ) -> dict[str, NCBIGenbank]:
     """Download a batch of records and return in a dictionary indexed by accession."""
+    fetch_logger = logger.bind(
+        accession_count=len(accessions),
+        chunk_size=chunk_size,
+        ignore_cache=ignore_cache,
+    )
+
     if not accessions:
         return {}
 
@@ -200,11 +206,17 @@ def batch_fetch_new_records(
 
     fetch_list = list(accessions)
 
+    page_counter = 0
+
     indexed_records = {}
     for fetch_list_chunk in iter_fetch_list(fetch_list, chunk_size):
+        fetch_logger.info("Fetching records...", page_counter=page_counter)
+
         chunked_records = ncbi.fetch_genbank_records(fetch_list_chunk)
 
         indexed_records.update({record.accession: record for record in chunked_records})
+
+        page_counter += 1
 
     if indexed_records:
         return indexed_records

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from collections.abc import Collection, Iterable, Iterator
 from uuid import UUID
 
+from pydantic import RootModel
 from structlog import get_logger
 
 from ref_builder.ncbi.client import NCBIClient
@@ -29,6 +30,10 @@ OTU_FEEDBACK_INTERVAL = 100
 
 RECORD_FETCH_CHUNK_SIZE = 500
 """A default chunk size for NCBI EFetch calls."""
+
+
+BatchFetchIndex = RootModel[dict[int, set[str]]]
+"""Assists in reading and writing the fetched accessions by taxid index from file."""
 
 
 def auto_update_otu(


### PR DESCRIPTION

* after running `batch_fetch_new_accessions()`, save the resulting fetch index of new accessions to `.cache`
* add `--fetch-index-path PATH`, allowing the user to input a previously saved fetch-index
* add `--precache`, `--precache-batch-size` to control whether all records are precached before adding to repo and how many records should be fetched at once.