### PR TITLE
fix: address `logger.exception()` related crashes

### DIFF
--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -305,8 +305,8 @@ def update_isolate_from_records(
     else:
         try:
             assigned = assign_records_to_segments(records, otu.plan)
-        except ValueError:
-            logger.exception()
+        except ValueError as e:
+            logger.debug(e)
             return None
 
     for segment_id, record in assigned.items():

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -530,18 +530,19 @@ def promote_otu_accessions_from_records(
             promoted_isolate = update_isolate_from_records(
                 repo, otu, isolate_id, records
             )
-        except ValueError:
-            logger.exception()
+        except ValueError as e:
+            logger.debug(e)
             continue
 
-        otu_logger.info(
-            f"Isolate promoted using RefSeq data",
-            isolate_id=str(isolate.id),
-            isolate_name=str(isolate.name) if isolate.name is not None else None,
-            accessions=promoted_isolate.accessions,
-        )
+        if promoted_isolate is not None:
+            otu_logger.info(
+                f"Isolate promoted using RefSeq data",
+                isolate_id=str(isolate.id),
+                isolate_name=str(isolate.name) if isolate.name is not None else None,
+                accessions=promoted_isolate.accessions,
+            )
 
-        promoted_accessions.update(promoted_isolate.accessions)
+            promoted_accessions.update(promoted_isolate.accessions)
 
     if promoted_accessions:
         otu = repo.get_otu(otu.id)


### PR DESCRIPTION
Removes crashes caused by improper use of `structlog` `.exception()`