### PR TITLE
REF-36: Index event timestamps

### DIFF
--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -174,6 +174,23 @@ class Index:
 
         return None
 
+    def get_first_timestamp_by_otu_id(self, otu_id: UUID) -> datetime.datetime | None:
+        """Get the timestamp of the earliest event associated with this ID."""
+        cursor = self.con.execute(
+            """
+            SELECT timestamp
+            FROM events
+            WHERE otu_id = ?
+            ORDER BY event_id
+            """,
+            (str(otu_id),),
+        )
+
+        if result := cursor.fetchone():
+            return datetime.datetime.fromisoformat(result[0])
+
+        return None
+
     def get_latest_timestamp_by_otu_id(self, otu_id: UUID) -> datetime.datetime | None:
         """Get the timestamp of the latest event associated with this ID."""
         cursor = self.con.execute(

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -1,6 +1,7 @@
 """An index for improving repository performance."""
 
 import binascii
+import datetime
 import sqlite3
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -61,7 +62,8 @@ class Index:
             """
             CREATE TABLE IF NOT EXISTS events (
                 event_id INTEGER PRIMARY KEY,
-                otu_id TEXT
+                otu_id TEXT,
+                timestamp TEXT
             );
             """,
         )
@@ -124,22 +126,29 @@ class Index:
         """A list of all OTUs tracked in the index."""
         return {UUID(row[0]) for row in self.con.execute("SELECT id FROM otus")}
 
-    def add_event_id(self, event_id: int, otu_id: UUID) -> None:
+    def add_event_id(
+        self,
+        event_id: int,
+        otu_id: UUID,
+        timestamp: datetime.datetime,
+    ) -> None:
         """Add a new event ID and associated it with a given OTU ID.
 
         This allows fast lookup of event IDs for a given OTU ID.
 
         :param event_id: the event ID to add
         :param otu_id: the OTU ID to add the event ID to
+        :param timestamp: the timestamp of the event
         """
         self.con.execute(
             """
-            INSERT INTO events (event_id, otu_id)
-            VALUES (?, ?)
+            INSERT INTO events (event_id, otu_id, timestamp)
+            VALUES (?, ?, ?)
             """,
             (
                 event_id,
                 str(otu_id),
+                timestamp.isoformat(),
             ),
         )
 

--- a/ref_builder/index.py
+++ b/ref_builder/index.py
@@ -174,6 +174,23 @@ class Index:
 
         return None
 
+    def get_latest_timestamp_by_otu_id(self, otu_id: UUID) -> datetime.datetime | None:
+        """Get the timestamp of the latest event associated with this ID."""
+        cursor = self.con.execute(
+            """
+            SELECT timestamp
+            FROM events
+            WHERE otu_id = ?
+            ORDER BY event_id DESC
+            """,
+            (str(otu_id),),
+        )
+
+        if result := cursor.fetchone():
+            return datetime.datetime.fromisoformat(result[0])
+
+        return None
+
     def get_id_by_legacy_id(self, legacy_id: str) -> UUID | None:
         """Get an OTU ID by its legacy ID."""
         cursor = self.con.execute(

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -761,12 +761,20 @@ class Repo:
         if event_index_item is None:
             return None
 
-        events = (
-            self._event_store.read_event(event_id)
-            for event_id in event_index_item.event_ids
-        )
+        try:
+            events = (
+                self._event_store.read_event(event_id)
+                for event_id in event_index_item.event_ids
+            )
 
-        otu = self._rehydrate_otu(events)
+            otu = self._rehydrate_otu(events)
+
+        except FileNotFoundError:
+            logger.error("Event exists in index, but not in source. Deleting index...")
+
+            self.clear_index()
+
+            raise
 
         self._index.upsert_otu(otu, self.last_id)
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -291,6 +291,23 @@ class Repo:
         self._index.prune(self.head_id)
         self._event_store.prune(self.head_id)
 
+    def clear_index(self) -> bool:
+        """Delete and replace the repository read index."""
+
+        index_path = self._index.path
+
+        if index_path.exists():
+            index_path.unlink()
+
+            (index_path.parent / f"{index_path.stem}.db-shm").unlink()
+            (index_path.parent / f"{index_path.stem}.db-wal").unlink()
+
+            self._index = Index(index_path)
+
+            return True
+
+        return False
+
     def iter_minimal_otus(self) -> Iterator[OTUMinimal]:
         """Iterate over minimal representations of the OTUs in the repository.
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -839,6 +839,10 @@ class Repo:
 
         return self._index.get_isolate_id_by_partial(partial)
 
+    def get_otu_first_created(self, otu_id: uuid.UUID) -> datetime.datetime | None:
+        """Get the timestamp of the first event associated with an OTU."""
+        return self._index.get_first_timestamp_by_otu_id(otu_id)
+
     def get_otu_last_modified(self, otu_id: uuid.UUID) -> datetime.datetime | None:
         """Get the timestamp of the last event associated with an OTU."""
         return self._index.get_latest_timestamp_by_otu_id(otu_id)

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -895,7 +895,9 @@ class Repo:
 
         if hasattr(event.query, "otu_id"):
             self._index.add_event_id(
-                event.id, event.query.otu_id, timestamp=event.timestamp,
+                event.id,
+                event.query.otu_id,
+                timestamp=event.timestamp,
             )
 
         return event

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -311,7 +311,7 @@ class Repo:
             except KeyError:
                 continue
 
-            self._index.add_event_id(event.id, otu_id)
+            self._index.add_event_id(event.id, otu_id, event.timestamp)
 
     def iter_minimal_otus(self) -> Iterator[OTUMinimal]:
         """Iterate over minimal representations of the OTUs in the repository.
@@ -894,7 +894,9 @@ class Repo:
         )
 
         if hasattr(event.query, "otu_id"):
-            self._index.add_event_id(event.id, event.query.otu_id)
+            self._index.add_event_id(
+                event.id, event.query.otu_id, timestamp=event.timestamp,
+            )
 
         return event
 

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -129,17 +129,7 @@ class Repo:
 
         # Populate the index if it is empty.
         if not self._index.otu_ids:
-            logger.info("No index found. Rebuilding...")
-            for otu in self.iter_otus_from_events():
-                self._index.upsert_otu(otu, self.last_id)
-
-            for event in self._event_store.iter_events():
-                try:
-                    otu_id = event.query.model_dump()["otu_id"]
-                except KeyError:
-                    continue
-
-                self._index.add_event_id(event.id, otu_id)
+            self.rebuild_index()
 
     @classmethod
     def new(
@@ -307,6 +297,21 @@ class Repo:
             return True
 
         return False
+
+    def rebuild_index(self) -> None:
+        """Rebuild the repository read index."""
+
+        logger.info("No index found. Rebuilding...")
+        for otu in self.iter_otus_from_events():
+            self._index.upsert_otu(otu, self.last_id)
+
+        for event in self._event_store.iter_events():
+            try:
+                otu_id = event.query.model_dump()["otu_id"]
+            except KeyError:
+                continue
+
+            self._index.add_event_id(event.id, otu_id)
 
     def iter_minimal_otus(self) -> Iterator[OTUMinimal]:
         """Iterate over minimal representations of the OTUs in the repository.

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -13,6 +13,7 @@ TODO: Check for accession conflicts.
 
 """
 
+import datetime
 import shutil
 import uuid
 from collections import defaultdict
@@ -837,6 +838,10 @@ class Repo:
             )
 
         return self._index.get_isolate_id_by_partial(partial)
+
+    def get_otu_last_modified(self, otu_id: uuid.UUID) -> datetime.datetime | None:
+        """Get the timestamp of the last event associated with an OTU."""
+        return self._index.get_latest_timestamp_by_otu_id(otu_id)
 
     def _rehydrate_otu(self, events: Iterator[Event]) -> RepoOTU:
         event = next(events)

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -293,8 +293,6 @@ class Repo:
             (index_path.parent / f"{index_path.stem}.db-shm").unlink()
             (index_path.parent / f"{index_path.stem}.db-wal").unlink()
 
-            self._index = Index(index_path)
-
             return True
 
         return False

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -125,6 +125,22 @@ class TestEvents:
         """Test that we get ``None`` when an OTU ID is not found."""
         assert index.get_event_ids_by_otu_id(uuid.uuid4()) is None
 
+    def test_get_first_timestamp_ok(self, index: Index, indexable_otus: list[RepoOTU]):
+        """Test ``.get_first_timestamp_by_otu_id()`` retrieves the first timestamp."""
+        otu = indexable_otus[1]
+
+        first_timestamp = arrow.utcnow().naive
+
+        index.add_event_id(100, otu.id, first_timestamp)
+
+        assert index.get_first_timestamp_by_otu_id(otu.id) == first_timestamp
+
+        second_timestamp = arrow.utcnow().naive
+
+        index.add_event_id(101, otu.id, second_timestamp)
+
+        assert index.get_first_timestamp_by_otu_id(otu.id) == first_timestamp
+
     def test_get_latest_timestamp_ok(self, index: Index, indexable_otus: list[RepoOTU]):
         """Test ``.get_latest_timestamp_by_otu_id()`` retrieves the latest timestamp."""
         otu = indexable_otus[1]

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -125,6 +125,26 @@ class TestEvents:
         """Test that we get ``None`` when an OTU ID is not found."""
         assert index.get_event_ids_by_otu_id(uuid.uuid4()) is None
 
+    def test_get_latest_timestamp_ok(self, index: Index, indexable_otus: list[RepoOTU]):
+        """Test ``.get_latest_timestamp_by_otu_id()`` retrieves the latest timestamp."""
+        otu = indexable_otus[1]
+
+        index.add_event_id(100, otu.id, arrow.utcnow().naive)
+
+        first_timestamp = arrow.utcnow().naive
+
+        index.add_event_id(101, otu.id, first_timestamp)
+
+        assert index.get_latest_timestamp_by_otu_id(otu.id) == first_timestamp
+
+        second_timestamp = arrow.utcnow().naive
+
+        index.add_event_id(104, otu.id, second_timestamp)
+
+        assert second_timestamp > first_timestamp
+
+        assert index.get_latest_timestamp_by_otu_id(otu.id) == second_timestamp
+
 
 class TestGetIDByPartial:
     """Test the `get_id_by_partial` method of the Snapshotter class."""

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -3,6 +3,7 @@
 import uuid
 from pathlib import Path
 
+import arrow
 import pytest
 
 from ref_builder.index import EventIndexItem, Index
@@ -111,9 +112,9 @@ class TestEvents:
         """Test that we can set and get events IDs for an OTU."""
         otu = indexable_otus[1]
 
-        index.add_event_id(100, otu.id)
-        index.add_event_id(101, otu.id)
-        index.add_event_id(104, otu.id)
+        index.add_event_id(100, otu.id, arrow.utcnow().naive)
+        index.add_event_id(101, otu.id, arrow.utcnow().naive)
+        index.add_event_id(104, otu.id, arrow.utcnow().naive)
 
         assert index.get_event_ids_by_otu_id(otu.id) == EventIndexItem(
             event_ids=[100, 101, 104],


### PR DESCRIPTION
Add a `timestamp` column to the `events` table in the repo's index. This allows for quick lookup of the last modification to an OTU.

* add `Index.get_latest_timestamp_by_otu_id()`
* add: `Repo.get_otu_last_modified()`
* chore: `Repo.get_otu()`: if `FileNotFoundError` while rehydrating (usually because index contains a nonexistent event), assume the cached index is invalid and delete it