### PR TITLE
disallow deletion of an OTU's representative isolate

### DIFF
--- a/ref_builder/cli/isolate.py
+++ b/ref_builder/cli/isolate.py
@@ -150,9 +150,11 @@ def isolate_delete(repo: Repo, identifier: str) -> None:
         click.echo(f"OTU not found.", err=True)
         sys.exit(1)
 
-    delete_isolate_from_otu(repo, otu_, isolate_id)
+    if delete_isolate_from_otu(repo, otu_, isolate_id):
+        click.echo("Isolate deleted.")
 
-    click.echo("Isolate deleted.")
+    else:
+        sys.exit(1)
 
 
 @isolate.command(name="get")

--- a/ref_builder/otu/modify.py
+++ b/ref_builder/otu/modify.py
@@ -84,13 +84,16 @@ def delete_isolate_from_otu(repo: Repo, otu: RepoOTU, isolate_id: UUID) -> bool:
     otu_logger = logger.bind(otu_id=str(otu.id), taxid=otu.taxid)
 
     if isolate_id == otu.representative_isolate:
-        otu_logger.error("The representative isolate cannot be deleted from the OTU.")
+        otu_logger.error(
+            "The representative isolate cannot be deleted from the OTU.",
+            isolate_id=str(isolate_id),
+        )
         return False
 
     isolate = otu.get_isolate(isolate_id)
 
     if not isolate:
-        otu_logger.error("Isolate not found.", isolate_id=isolate_id)
+        otu_logger.error("Isolate not found.", isolate_id=str(isolate_id))
         return False
 
     with repo.use_transaction():
@@ -99,8 +102,8 @@ def delete_isolate_from_otu(repo: Repo, otu: RepoOTU, isolate_id: UUID) -> bool:
     otu_logger.info(
         "Isolate removed.",
         name=isolate.name,
-        removed_isolate_id=isolate_id,
-        current_isolate_ids=list[otu.isolate_ids],
+        removed_isolate_id=str(isolate_id),
+        current_isolate_ids=[str(isolate_id_) for isolate_id_ in otu.isolate_ids],
     )
 
     repo.get_otu(otu.id)

--- a/ref_builder/otu/modify.py
+++ b/ref_builder/otu/modify.py
@@ -79,15 +79,19 @@ def allow_accessions_into_otu(
         )
 
 
-def delete_isolate_from_otu(repo: Repo, otu: RepoOTU, isolate_id: UUID) -> None:
+def delete_isolate_from_otu(repo: Repo, otu: RepoOTU, isolate_id: UUID) -> bool:
     """Remove an isolate from a specified OTU."""
     otu_logger = logger.bind(otu_id=str(otu.id), taxid=otu.taxid)
+
+    if isolate_id == otu.representative_isolate:
+        otu_logger.error("The representative isolate cannot be deleted from the OTU.")
+        return False
 
     isolate = otu.get_isolate(isolate_id)
 
     if not isolate:
         otu_logger.error("Isolate not found.", isolate_id=isolate_id)
-        return
+        return False
 
     with repo.use_transaction():
         repo.delete_isolate(otu.id, isolate.id, rationale=DeleteRationale.USER)
@@ -98,6 +102,10 @@ def delete_isolate_from_otu(repo: Repo, otu: RepoOTU, isolate_id: UUID) -> None:
         removed_isolate_id=isolate_id,
         current_isolate_ids=list[otu.isolate_ids],
     )
+
+    repo.get_otu(otu.id)
+
+    return True
 
 
 def set_plan(

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -421,6 +421,15 @@ class Repo:
         rationale: str,
     ) -> None:
         """Delete an existing isolate from a given OTU."""
+        if (otu_ := self.get_otu(otu_id)) is None:
+            raise ValueError(f"OTU does not exist: {otu_id}")
+
+        if isolate_id not in otu_.isolate_ids:
+            raise ValueError(f"Isolate does not exist: {isolate_id}")
+
+        if isolate_id == otu_.representative_isolate:
+            raise ValueError(f"Representative isolate cannot be deleted.")
+
         self._write_event(
             DeleteIsolate,
             DeleteIsolateData(rationale=rationale),

--- a/tests/cli/test_isolate_commands.py
+++ b/tests/cli/test_isolate_commands.py
@@ -228,3 +228,20 @@ class TestIsolateDeleteCommand:
         )
 
         assert result.exit_code == 1
+
+    def test_delete_representative_isolate_fail(self, scratch_repo):
+        otu = scratch_repo.get_otu_by_taxid(1169032)
+
+        result = runner.invoke(
+            isolate_command_group,
+            [
+                "--path",
+                str(scratch_repo.path),
+                "delete",
+                str(otu.representative_isolate),
+            ],
+        )
+
+        assert result.exit_code == 1
+
+        assert "representative isolate cannot be deleted from the OTU" in result.output

--- a/tests/cli/test_otu_commands.py
+++ b/tests/cli/test_otu_commands.py
@@ -113,7 +113,8 @@ class TestCreateOTUCommands:
         assert "Duplicate accessions are not allowed." in result.output
 
 
-class TestPromoteCommand:
+@pytest.mark.ncbi
+class TestPromoteOTUCommand:
     """Test that the ``ref-builder otu promote`` command works as planned."""
 
     def test_promotable_ok(self, empty_repo: Repo):
@@ -278,33 +279,3 @@ class TestAllowAccessionsCommand:
         assert result.exit_code == 0
 
         assert "Excluded accession list already up to date" in result.output
-
-
-class TestPromoteOTUCommand:
-    """Test that ``ref-builder otu promote`` behaves as expected."""
-
-    def test_ok(self, precached_repo: Repo):
-        taxid = 2164102
-
-        rep_isolate_accessions = {"MF062125", "MF062126", "MF062127"}
-
-        path_option = ["--path", str(precached_repo.path)]
-
-        result = runner.invoke(
-            otu_command_group,
-            path_option
-            + ["create", "--taxid", str(taxid)]
-            + list(rep_isolate_accessions),
-        )
-
-        assert result.exit_code == 0
-
-        result = runner.invoke(otu_command_group, path_option + ["promote", str(taxid)])
-
-        assert result.exit_code == 0
-
-        otu_after = precached_repo.get_otu_by_taxid(taxid)
-
-        assert otu_after.excluded_accessions == rep_isolate_accessions
-
-        assert otu_after.accessions == {"NC_055390", "NC_055391", "NC_055392"}

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -346,6 +346,8 @@ class TestUpdateRepresentativeIsolateCommand:
 
 
 class TestDeleteIsolate:
+    """Test isolate deletion behaviour."""
+
     def test_ok(self, scratch_repo):
         """Test that a given isolate can be deleted from the OTU."""
         taxid = 1169032
@@ -359,7 +361,7 @@ class TestDeleteIsolate:
         assert type(isolate_id) is UUID
 
         with scratch_repo.lock():
-            delete_isolate_from_otu(scratch_repo, otu_before, isolate_id)
+            assert delete_isolate_from_otu(scratch_repo, otu_before, isolate_id)
 
         otu_after = scratch_repo.get_otu_by_taxid(taxid)
 
@@ -370,6 +372,21 @@ class TestDeleteIsolate:
         assert otu_before.get_isolate(isolate_id).accessions not in otu_after.accessions
 
         assert len(otu_after.isolate_ids) == len(otu_before.isolate_ids) - 1
+
+    def test_representative_isolate_fail(self, scratch_repo: Repo):
+        """Test that the representative isolate cannot be deleted."""
+        taxid = 1169032
+
+        otu_before = scratch_repo.get_otu_by_taxid(taxid)
+
+        with scratch_repo.lock():
+            assert not delete_isolate_from_otu(
+                scratch_repo,
+                otu_before,
+                isolate_id=otu_before.representative_isolate,
+            )
+
+        assert scratch_repo.get_otu(otu_before.id).isolate_ids == otu_before.isolate_ids
 
 
 class TestReplaceSequence:


### PR DESCRIPTION
* add `TestDeleteIsolate` to `test_repo`
* chore: remove duplicate `otu promote` test
* chore: mark `TestPromoteOTUCommand` as NCBI-dependent