### PR TITLE
improvements to `otu update` and `otu batch-update`

### DIFF
--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -178,14 +178,14 @@ def batch_update_repo(
         else:
             otu_iterator = repo.iter_otus()
 
-        taxid_new_accession_index = batch_fetch_new_accessions(
+        batch_fetch_index = batch_fetch_new_accessions(
             otu_iterator,
             modification_date_start=start_date,
             ignore_cache=ignore_cache,
         )
 
         fetch_index_cache_path = _cache_fetch_index(
-            taxid_new_accession_index, repo.path / ".cache"
+            batch_fetch_index, repo.path / ".cache"
         )
 
         repo_logger.info("Fetch index cached", fetch_index_path=fetch_index_cache_path)
@@ -195,43 +195,43 @@ def batch_update_repo(
             "Loading fetch index...", fetch_index_path=str(fetch_index_path)
         )
 
-        taxid_new_accession_index = _load_fetch_index(fetch_index_path)
+        batch_fetch_index = _load_fetch_index(fetch_index_path)
 
-    if not taxid_new_accession_index:
+    if not batch_fetch_index:
         logger.info("OTUs are up to date.")
 
         return updated_otu_ids
 
     logger.info(
         "Batch fetch index contains potential new accessions.",
-        otu_count=len(taxid_new_accession_index),
+        otu_count=len(batch_fetch_index),
     )
 
     if precache_records:
         fetch_set = {
             accession
-            for otu_accessions in taxid_new_accession_index.values()
+            for otu_accessions in batch_fetch_index.values()
             for accession in otu_accessions
         }
 
         logger.info("Precaching records...", accession_count=len(fetch_set))
 
-        indexed_records = batch_fetch_new_records(
+        record_index_by_accession = batch_fetch_new_records(
             fetch_set,
             chunk_size=chunk_size,
             ignore_cache=ignore_cache,
         )
 
-        if not indexed_records:
+        if not record_index_by_accession:
             logger.info("No valid accessions found.")
             return updated_otu_ids
 
-        record_getter = PrecachedRecordStore(taxid_new_accession_index, indexed_records)
+        record_getter = PrecachedRecordStore(batch_fetch_index, record_index_by_accession)
 
     else:
-        record_getter = RecordFetcher(taxid_new_accession_index)
+        record_getter = RecordFetcher(batch_fetch_index)
 
-    for taxid, accessions in taxid_new_accession_index.items():
+    for taxid, accessions in batch_fetch_index.items():
         if (otu_id := repo.get_otu_id_by_taxid(taxid)) is None:
             logger.debug("No corresponding OTU found in this repo", taxid=taxid)
             continue
@@ -261,7 +261,7 @@ def batch_update_repo(
 
         repo.write_otu_update_history_entry(otu_id)
 
-    repo_logger.info("Batch update complete.")
+    repo_logger.info("Batch update complete.", new_isolate_count=len(updated_otu_ids))
 
     return updated_otu_ids
 
@@ -648,7 +648,7 @@ def iter_fetch_list(
     page_count = len(fetch_list) // page_size + int(len(fetch_list) % page_size != 0)
 
     for iterator in range(page_count):
-        yield fetch_list[iterator * page_size : (iterator + 1) * page_size]
+        yield fetch_list[iterator * page_size: (iterator + 1) * page_size]
 
 
 def _generate_datestamp_filename():

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -124,7 +124,7 @@ class PrecachedRecordStore(BaseBatchRecordGetter):
         return otu_records
 
 
-class BatchRecordFetcher(BaseBatchRecordGetter):
+class RecordFetcher(BaseBatchRecordGetter):
     """Retrieves records from NCBI Nucleotide based on a batch fetch index
     set at initialization.
     """
@@ -265,7 +265,7 @@ def batch_update_repo(
             repo.write_otu_update_history_entry(otu_id)
 
     else:
-        ncbi = NCBIClient(ignore_cache)
+        record_getter = RecordFetcher(taxid_new_accession_index)
 
         for taxid, accessions in taxid_new_accession_index.items():
             if (otu_id := repo.get_otu_id_by_taxid(taxid)) is None:

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -252,7 +252,7 @@ def batch_update_repo(
         otu_records = record_getter.get_records(taxid)
 
         if otu_records:
-            isolate_ids = _process_records_into_otu(
+            isolate_ids = promote_and_update_otu_from_records(
                 repo, repo.get_otu(otu_id), otu_records
             )
 
@@ -434,11 +434,12 @@ def update_isolate_from_records(
     return isolate
 
 
-def _process_records_into_otu(
+def promote_and_update_otu_from_records(
     repo: Repo,
     otu: RepoOTU,
     records: list[NCBIGenbank],
 ):
+    """Promote new RefSeq accessions and add new isolates."""
     genbank_records, refseq_records = [], []
 
     for record in records:
@@ -488,7 +489,7 @@ def update_otu_with_accessions(
     records = ncbi.fetch_genbank_records(accessions)
 
     if records:
-        return _process_records_into_otu(repo, otu, records)
+        return promote_and_update_otu_from_records(repo, otu, records)
 
 
 def update_otu_with_records(

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -446,9 +446,6 @@ def promote_and_update_otu_from_records(
         if record.refseq:
             refseq_records.append(record)
 
-        else:
-            genbank_records.append(record)
-
     if promote_otu_accessions_from_records(
         repo,
         otu=repo.get_otu(otu.id),
@@ -459,7 +456,7 @@ def promote_and_update_otu_from_records(
     new_isolate_ids = update_otu_with_records(
         repo,
         otu=otu,
-        records=genbank_records,
+        records=records,
     )
 
     repo.get_otu(otu.id)

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -226,7 +226,9 @@ def batch_update_repo(
             logger.info("No valid accessions found.")
             return updated_otu_ids
 
-        record_getter = PrecachedRecordStore(batch_fetch_index, record_index_by_accession)
+        record_getter = PrecachedRecordStore(
+            batch_fetch_index, record_index_by_accession
+        )
 
     else:
         record_getter = RecordFetcher(batch_fetch_index)
@@ -648,7 +650,7 @@ def iter_fetch_list(
     page_count = len(fetch_list) // page_size + int(len(fetch_list) % page_size != 0)
 
     for iterator in range(page_count):
-        yield fetch_list[iterator * page_size: (iterator + 1) * page_size]
+        yield fetch_list[iterator * page_size : (iterator + 1) * page_size]
 
 
 def _generate_datestamp_filename():

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -653,25 +653,6 @@ def iter_fetch_list(
         yield fetch_list[iterator * page_size : (iterator + 1) * page_size]
 
 
-def _bin_refseq_records(
-    records: list[NCBIGenbank],
-) -> tuple[list[NCBIGenbank], list[NCBIGenbank]]:
-    """Return a list of GenBank records as two lists, RefSeq and non-RefSeq."""
-    refseq_records = []
-    non_refseq_records = []
-
-    for record in records:
-        if record.refseq:
-            refseq_records.append(record)
-        else:
-            non_refseq_records.append(record)
-
-    if len(refseq_records) + len(non_refseq_records) != len(records):
-        raise ValueError("Invalid total number of records")
-
-    return refseq_records, non_refseq_records
-
-
 def _generate_datestamp_filename():
     """Get the current UTC date and return as a a filename_safe string."""
     timestamp = arrow.utcnow().naive

--- a/ref_builder/otu/update.py
+++ b/ref_builder/otu/update.py
@@ -150,18 +150,18 @@ def batch_update_repo(
 
         return updated_otu_ids
 
-    fetch_set = {
-        accession
-        for otu_accessions in taxid_new_accession_index.values()
-        for accession in otu_accessions
-    }
-
     logger.info(
         "Batch fetch index contains potential new accessions.",
         otu_count=len(taxid_new_accession_index),
     )
 
     if precache_records:
+        fetch_set = {
+            accession
+            for otu_accessions in taxid_new_accession_index.values()
+            for accession in otu_accessions
+        }
+
         logger.info("Precaching records...", accession_count=len(fetch_set))
 
         indexed_records = batch_fetch_new_records(


### PR DESCRIPTION
 - fix: `update_otu_with_records()` no longer ignores RefSeq records during the isolate addition step
 - fix: `batch_update_repo()` skips concatenation of fetch set when `precache = False` 
 - add: `PrecachedRecordStore` and `BatchRecordFetcher` classes, derived from abstract base class `BaseBatchRecordGetter`
 - refactor: consolidate `if precache` split in `batch_update_repo()` using  `BaseBatchRecordGetter` children
 - remove: `_bin_refseq_records()`