### PR TITLE
improve `Repo.exclude_accessions()` and associated tests

### DIFF
--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -669,8 +669,9 @@ class Repo:
         except ValueError as e:
             if "Invalid accession key" in str(e):
                 logger.warning(
-                    "Invalid accession included in set. No changes were made to "
-                    "excluded accessions."
+                    "Invalid accession included in set. "
+                    "No changes were made to excluded accessions.",
+                    accessions=sorted(accessions),
                 )
 
                 return otu.excluded_accessions

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -640,13 +640,25 @@ class Repo:
         """
         otu = self.get_otu(otu_id)
 
-        if accession in otu.excluded_accessions:
-            logger.debug("Accession is already excluded.", accession=accession)
+        try:
+            accession_key = get_accession_key(accession)
+
+        except ValueError as e:
+            if "Invalid accession key" in str(e):
+                logger.warning(
+                    "Invalid accession included in set. "
+                    "No changes were made to excluded accessions.",
+                    accession=accession,
+                )
+            return otu.excluded_accessions
+
+        if accession_key in otu.excluded_accessions:
+            logger.debug("Accession is already excluded.", accession=accession_key)
         else:
             self._write_event(
                 UpdateExcludedAccessions,
                 UpdateExcludedAccessionsData(
-                    accessions={accession},
+                    accessions={accession_key},
                     action=ExcludedAccessionAction.EXCLUDE,
                 ),
                 OTUQuery(otu_id=otu_id),

--- a/ref_builder/utils.py
+++ b/ref_builder/utils.py
@@ -31,8 +31,6 @@ class Accession:
     @classmethod
     def from_string(cls, string: str) -> "Accession":
         """Create an Accession from a raw accession string."""
-        accession_parts = string.split(".")
-
         try:
             key, string_version = string.split(".")
         except ValueError as e:
@@ -149,7 +147,10 @@ def get_accession_key(raw: str) -> str:
     if GENBANK_ACCESSION_PATTERN.match(raw) or REFSEQ_ACCESSION_PATTERN.match(raw):
         return raw
 
-    versioned_accession = Accession.from_string(raw)
+    try:
+        versioned_accession = Accession.from_string(raw)
+    except ValueError:
+        raise ValueError("Invalid accession key")
 
     if GENBANK_ACCESSION_PATTERN.match(
         versioned_accession.key

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -846,24 +846,24 @@ class TestExcludeAccessions:
 
         accessions = {"TM100021", "TM100022", "TM100023"}
 
-        with empty_repo.lock():
-            with empty_repo.use_transaction():
-                empty_repo.exclude_accessions(otu_id, accessions)
+        with empty_repo.lock(), empty_repo.use_transaction():
+            empty_repo.exclude_accessions(otu_id, accessions)
 
-            otu_before = empty_repo.get_otu(otu_id)
+        otu_before = empty_repo.get_otu(otu_id)
 
-            assert empty_repo.last_id == 3
-            assert otu_before.excluded_accessions == accessions
+        assert (id_after_first_exclusion := empty_repo.last_id) == 3
 
-            with empty_repo.use_transaction():
-                empty_repo.exclude_accessions(otu_id, {"TM100023", "TM100024"})
+        assert otu_before.excluded_accessions == accessions
 
-            otu_after = empty_repo.get_otu(otu_id)
+        with empty_repo.lock(), empty_repo.use_transaction():
+            empty_repo.exclude_accessions(otu_id, {"TM100023", "TM100024"})
 
-            assert empty_repo.last_id == 4
-            assert otu_after.excluded_accessions == otu_before.excluded_accessions | {
-                "TM100024"
-            }
+        otu_after = empty_repo.get_otu(otu_id)
+
+        assert empty_repo.last_id == id_after_first_exclusion + 1
+        assert otu_after.excluded_accessions == (
+            otu_before.excluded_accessions | {"TM100024"}
+        )
 
         with open(
             empty_repo.path.joinpath("src", f"{empty_repo.last_id:08}.json")

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -657,7 +657,10 @@ class TestGetOTU:
 
             initialized_repo.link_sequence(otu.id, isolate.id, sequence_id=sequence.id)
 
-        assert initialized_repo.get_otu(otu.id).blocked_accessions == {"TMVABC", "TMVABCB"}
+        assert initialized_repo.get_otu(otu.id).blocked_accessions == {
+            "TMVABC",
+            "TMVABCB",
+        }
 
         with initialized_repo.lock(), initialized_repo.use_transaction():
             initialized_repo.exclude_accessions(otu.id, excludable_accessions)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -752,7 +752,10 @@ def test_get_isolate_id_from_partial(initialized_repo: Repo):
 
 
 class TestExcludeAccessions:
-    """Test that accessions can be excluded from future fetches."""
+    """Test that excluded accessions are reflected in events.
+
+    Excluded accessions are exempt from future queries to the NCBI Nucleotide.
+    """
 
     def test_ok(self, empty_repo: Repo):
         otu = init_otu(empty_repo)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -758,7 +758,10 @@ class TestExcludeAccessions:
     """
 
     def test_ok(self, empty_repo: Repo):
+        """Test that Repo.exclude_accessions() writes the correct event."""
         otu = init_otu(empty_repo)
+
+        assert (id_at_creation := empty_repo.last_id) == 2
 
         assert otu.excluded_accessions == set()
 
@@ -768,7 +771,7 @@ class TestExcludeAccessions:
             empty_repo.exclude_accessions(otu.id, accessions)
 
         assert empty_repo.get_otu(otu.id).excluded_accessions == accessions
-        assert empty_repo.last_id == 3
+        assert empty_repo.last_id == id_at_creation + 1 == 3
 
         with open(empty_repo.path / "src" / f"{empty_repo.last_id:08}.json") as f:
             event = orjson.loads(f.read())
@@ -790,7 +793,7 @@ class TestExcludeAccessions:
         with empty_repo.lock(), empty_repo.use_transaction():
             empty_repo.exclude_accessions(otu.id, {"TM100024"})
 
-        assert empty_repo.last_id == 4
+        assert empty_repo.last_id == id_at_creation + 2 == 4
         assert empty_repo.get_otu(otu.id).excluded_accessions == accessions | {
             "TM100024"
         }

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -637,6 +637,8 @@ class TestGetOTU:
         """
         otu = initialized_repo.get_otu_by_taxid(12242)
 
+        excludable_accessions = {"GR33333", "TL44322"}
+
         with initialized_repo.lock(), initialized_repo.use_transaction():
             sequence = initialized_repo.create_sequence(
                 otu.id,
@@ -655,14 +657,16 @@ class TestGetOTU:
 
             initialized_repo.link_sequence(otu.id, isolate.id, sequence_id=sequence.id)
 
-            initialized_repo.exclude_accession(otu.id, "GROK")
-            initialized_repo.exclude_accession(otu.id, "TOK")
+        assert initialized_repo.get_otu(otu.id).blocked_accessions == {"TMVABC", "TMVABCB"}
+
+        with initialized_repo.lock(), initialized_repo.use_transaction():
+            initialized_repo.exclude_accessions(otu.id, excludable_accessions)
 
         assert initialized_repo.get_otu(otu.id).blocked_accessions == {
             "TMVABC",
             "TMVABCB",
-            "GROK",
-            "TOK",
+            "GR33333",
+            "TL44322",
         }
 
 


### PR DESCRIPTION
* update `Repo.exclude_accession()` to match `.exclude_accessions()`
* better logs
* more readable tests