### PR TITLE
fix: account for NCBI Taxonomy lineage change

### DIFF
--- a/tests/ncbi/__snapshots__/test_client.ambr
+++ b/tests/ncbi/__snapshots__/test_client.ambr
@@ -21,5 +21,68 @@
   ])
 # ---
 # name: TestFetchTaxonomy.test_ok
-  NCBITaxonomy(id=1198450, name='Jacquemontia mosaic Yucatan virus', other_names=NCBITaxonomyOtherNames(acronym=[], genbank_acronym=[], equivalent_name=[], synonym=[], includes=[]), lineage=[NCBILineage(id=10239, name='Viruses', rank='no_rank'), NCBILineage(id=2731342, name='Monodnaviria', rank='realm'), NCBILineage(id=2732092, name='Shotokuvirae', rank='kingdom'), NCBILineage(id=2732416, name='Cressdnaviricota', rank='phylum'), NCBILineage(id=2732424, name='Repensiviricetes', rank='class'), NCBILineage(id=2732539, name='Geplafuvirales', rank='order'), NCBILineage(id=10811, name='Geminiviridae', rank='family'), NCBILineage(id=10814, name='Begomovirus', rank='genus')], rank=<NCBIRank.SPECIES: 'species'>, species=NCBILineage(id=1198450, name='Jacquemontia mosaic Yucatan virus', rank='species'))
+  dict({
+    'id': 1198450,
+    'lineage': list([
+      dict({
+        'id': 10239,
+        'name': 'Viruses',
+        'rank': 'acellular root',
+      }),
+      dict({
+        'id': 2731342,
+        'name': 'Monodnaviria',
+        'rank': 'realm',
+      }),
+      dict({
+        'id': 2732092,
+        'name': 'Shotokuvirae',
+        'rank': 'kingdom',
+      }),
+      dict({
+        'id': 2732416,
+        'name': 'Cressdnaviricota',
+        'rank': 'phylum',
+      }),
+      dict({
+        'id': 2732424,
+        'name': 'Repensiviricetes',
+        'rank': 'class',
+      }),
+      dict({
+        'id': 2732539,
+        'name': 'Geplafuvirales',
+        'rank': 'order',
+      }),
+      dict({
+        'id': 10811,
+        'name': 'Geminiviridae',
+        'rank': 'family',
+      }),
+      dict({
+        'id': 10814,
+        'name': 'Begomovirus',
+        'rank': 'genus',
+      }),
+    ]),
+    'name': 'Jacquemontia mosaic Yucatan virus',
+    'other_names': dict({
+      'acronym': list([
+      ]),
+      'equivalent_name': list([
+      ]),
+      'genbank_acronym': list([
+      ]),
+      'includes': list([
+      ]),
+      'synonym': list([
+      ]),
+    }),
+    'rank': <NCBIRank.SPECIES: 'species'>,
+    'species': dict({
+      'id': 1198450,
+      'name': 'Jacquemontia mosaic Yucatan virus',
+      'rank': 'species',
+    }),
+  })
 # ---

--- a/tests/ncbi/test_client.py
+++ b/tests/ncbi/test_client.py
@@ -232,7 +232,9 @@ class TestFetchTaxonomy:
         assert uncached_ncbi_client.cache.load_taxonomy(1198450) is None
 
         # Fetch the taxonomy record and check its contents.
-        assert uncached_ncbi_client.fetch_taxonomy_record(1198450) == snapshot
+        assert (
+            uncached_ncbi_client.fetch_taxonomy_record(1198450).model_dump() == snapshot
+        )
 
         # Make sure the taxid is now cached.
         assert uncached_ncbi_client.cache.load_taxonomy(1198450)


### PR DESCRIPTION
* NCBI Taxonomy now [ranks "Viruses" as "acellular root"](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=10239&lvl=3&lin=f&keep=1&srchmode=1&unlock)
* snapshot dumped model for readability