### PR TITLE
REF-5: Warn about no required segments when creating OTUs

### DIFF
--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -16,6 +16,10 @@ COMPLEX_NAME_PATTERN = re.compile(r"([A-Za-z]+)[-_ ]+(.*)")
 """Regex pattern for parsing segment name strings consisting of a prefix and a key."""
 
 
+class PlanWarning(UserWarning):
+    pass
+
+
 class SegmentRule(StrEnum):
     """Mark the importance of a particular segment."""
 

--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -1,10 +1,11 @@
 import datetime
+import warnings
 from uuid import UUID
 
 from pydantic import UUID4, BaseModel, Field, field_serializer, field_validator
 
 from ref_builder.models import Molecule
-from ref_builder.plan import Plan
+from ref_builder.plan import Plan, PlanWarning
 from ref_builder.utils import Accession, DataType, IsolateName
 
 
@@ -348,3 +349,11 @@ class RepoOTU(BaseModel):
     def unlink_sequence(self, isolate_id: UUID4, sequence_id: UUID4) -> None:
         """Unlink the given sequence from the given isolate. Used only during rehydration."""
         self.get_isolate(isolate_id).delete_sequence(sequence_id)
+
+    @field_validator("plan", mode="after")
+    def check_plan_required(cls, value: Plan):
+        """Issue a warning if the plan has no required segments."""
+        if not value.required_segments:
+            warnings.warn("Plan has no required segments.", PlanWarning)
+
+        return value

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 import pytest
 
 from ref_builder.models import Molecule, MolType, Strandedness, Topology
-from ref_builder.plan import Plan, Segment
+from ref_builder.plan import Plan, PlanWarning, Segment, SegmentRule
 from ref_builder.repo import Repo
 from ref_builder.resources import RepoIsolate, RepoOTU
 from ref_builder.utils import IsolateName, IsolateNameType
@@ -57,6 +57,39 @@ class TestIsolate:
 
 class TestOTU:
     """Test properties of RepoOTU."""
+
+    def test_no_required_segments(self):
+        """Test that RepoOTU raises a warning if initialized without required segments."""
+        with pytest.warns(PlanWarning):
+            otu = RepoOTU(
+                id=uuid4(),
+                acronym="TMV",
+                excluded_accessions=set(),
+                isolates=[],
+                legacy_id=None,
+                molecule=Molecule(
+                    strandedness=Strandedness.SINGLE,
+                    type=MolType.RNA,
+                    topology=Topology.LINEAR,
+                ),
+                name="Tobacco mosaic virus",
+                representative_isolate=None,
+                plan=Plan(
+                    id=uuid4(),
+                    segments=[
+                        Segment(
+                            id=uuid4(),
+                            length=6395,
+                            length_tolerance=0.03,
+                            name=None,
+                            rule=SegmentRule.RECOMMENDED,
+                        )
+                    ],
+                ),
+                taxid=12242,
+            )
+
+        assert not otu.plan.required_segments
 
     def test_no_isolates(self):
         """Test that an isolate initializes correctly with no isolates."""


### PR DESCRIPTION
Add `RepoOTU.check_plan_required()` field validator.