### PR TITLE
fix: bad `PlanFactory` segments, unhelpful console output

### DIFF
--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -931,7 +931,9 @@ class Repo:
         except FileNotFoundError:
             return None
 
-    def _rehydrate_otu(self, events: Iterator[Event]) -> RepoOTU:
+    @staticmethod
+    def _rehydrate_otu(events: Iterator[Event]) -> RepoOTU:
+        """Rehydrate an OTU from an event iterator."""
         event = next(events)
 
         with warnings.catch_warnings(record=True) as warning_list:

--- a/ref_builder/repo.py
+++ b/ref_builder/repo.py
@@ -16,6 +16,7 @@ TODO: Check for accession conflicts.
 import datetime
 import shutil
 import uuid
+import warnings
 from collections import defaultdict
 from collections.abc import Collection, Generator, Iterator
 from contextlib import contextmanager
@@ -25,10 +26,10 @@ import arrow
 from structlog import get_logger
 
 from ref_builder.errors import (
+    InvalidInputError,
     LockRequiredError,
     TransactionExistsError,
     TransactionRequiredError,
-    InvalidInputError,
 )
 from ref_builder.events.base import (
     ApplicableEvent,
@@ -933,20 +934,29 @@ class Repo:
     def _rehydrate_otu(self, events: Iterator[Event]) -> RepoOTU:
         event = next(events)
 
-        if isinstance(event, CreateOTU):
-            otu = event.apply()
-        else:
-            raise TypeError(
-                f"The first event ({event}) for an OTU is not a CreateOTU " "event",
-            )
+        with warnings.catch_warnings(record=True) as warning_list:
+            if isinstance(event, CreateOTU):
+                otu = event.apply()
 
-        for event in events:
-            if not isinstance(event, ApplicableEvent):
+            else:
                 raise TypeError(
-                    f"Event {event.id} {event.type} is not an applicable event."
+                    f"The first event ({event}) for an OTU is not a CreateOTU " "event",
                 )
 
-            otu = event.apply(otu)
+            for event in events:
+                if not isinstance(event, ApplicableEvent):
+                    raise TypeError(
+                        f"Event {event.id} {event.type} is not an applicable event."
+                    )
+
+                otu = event.apply(otu)
+
+        for warning_msg in warning_list:
+            logger.warning(
+                warning_msg.message,
+                otu_id=str(otu.id),
+                warning_category=warning_msg.category.__name__,
+            )
 
         otu.isolates.sort(
             key=lambda i: f"{i.name.type} {i.name.value}"

--- a/ref_builder/resources.py
+++ b/ref_builder/resources.py
@@ -356,6 +356,6 @@ class RepoOTU(BaseModel):
     def check_plan_required(cls, value: Plan):
         """Issue a warning if the plan has no required segments."""
         if not value.required_segments:
-            warnings.warn("Plan has no required segments.", PlanWarning)
+            warnings.warn("Plan has no required segments.", PlanWarning, stacklevel=1)
 
         return value

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -252,7 +252,7 @@ class PlanFactory(ModelFactory[Plan]):
         """Return a set of quasi-realistic segments."""
         # The segment represent a monopartite OTU 75% of the time.
         if cls.__faker__.random_int(0, 3):
-            return [SegmentFactory.build(name=None, required=SegmentRule.REQUIRED)]
+            return [SegmentFactory.build(name=None, rule=SegmentRule.REQUIRED)]
 
         segment_count = cls.__faker__.random_int(2, 5)
         segment_name_keys = "ABCDEF"
@@ -260,7 +260,7 @@ class PlanFactory(ModelFactory[Plan]):
         return [
             SegmentFactory.build(
                 name=SegmentName(prefix="DNA", key=segment_name_keys[i]),
-                required=SegmentRule.REQUIRED,
+                rule=SegmentRule.REQUIRED,
             )
             for i in range(segment_count)
         ]


### PR DESCRIPTION
Fixes invalid `SegmentFactory.build()` in `PlanFactory`.

* `Repo._rehydrate_otu()`: catch and record warnings for logging
* make `._rehydrate_otu()` into `staticmethod`