### PR TITLE
refactor: `add_segments_to_plan()`

### DIFF
--- a/ref_builder/cli/otu.py
+++ b/ref_builder/cli/otu.py
@@ -390,14 +390,13 @@ def plan_extend_segment_list(
         click.echo(f"OTU {taxid} not found.", err=True)
         sys.exit(1)
 
-    with repo.use_transaction():
-        add_segments_to_plan(
-            repo,
-            otu_,
-            rule=SegmentRule.OPTIONAL if optional else SegmentRule.RECOMMENDED,
-            accessions=accessions_,
-            ignore_cache=ignore_cache,
-        )
+    add_segments_to_plan(
+        repo,
+        otu_,
+        rule=SegmentRule.OPTIONAL if optional else SegmentRule.RECOMMENDED,
+        accessions=accessions_,
+        ignore_cache=ignore_cache,
+    )
 
 
 @otu.command(name="rename-plan-segment")

--- a/ref_builder/otu/modify.py
+++ b/ref_builder/otu/modify.py
@@ -217,7 +217,7 @@ def add_segments_to_plan(
         log.error("Could not create all new segments.")
         return set()
 
-    new_plan = otu.plan.copy()
+    new_plan = otu.plan.model_copy()
     new_plan.segments.extend(new_segments)
 
     set_plan(repo, otu, new_plan)

--- a/ref_builder/otu/modify.py
+++ b/ref_builder/otu/modify.py
@@ -213,6 +213,10 @@ def add_segments_to_plan(
         log.warning("No segments can be added.")
         return set()
 
+    if len(new_segments) < len(accessions):
+        log.error("Could not create all new segments.")
+        return set()
+
     new_plan = otu.plan.copy()
     new_plan.segments.extend(new_segments)
 

--- a/ref_builder/plan.py
+++ b/ref_builder/plan.py
@@ -128,6 +128,11 @@ class Plan(BaseModel):
     """A list of segments that define the plan."""
 
     @property
+    def segment_ids(self) -> set[UUID]:
+        """Return all segment IDs as a set."""
+        return {segment.id for segment in self.segments}
+
+    @property
     def monopartite(self) -> bool:
         """Whether the plan is monopartite."""
         return len(self.segments) == 1

--- a/tests/__snapshots__/test_modify.ambr
+++ b/tests/__snapshots__/test_modify.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestSetPlan.test_add_segments_to_plan_ok[accessions0]
+# name: TestSetPlan.test_add_segments_to_plan_ok[initial_accessions0-new_accessions0]
   dict({
     'segments': list([
       dict({
@@ -32,7 +32,7 @@
     ]),
   })
 # ---
-# name: TestSetPlan.test_add_segments_to_plan_ok[accessions1]
+# name: TestSetPlan.test_add_segments_to_plan_ok[initial_accessions1-new_accessions1]
   dict({
     'segments': list([
       dict({
@@ -43,6 +43,15 @@
           'prefix': 'RNA',
         }),
         'rule': 'required',
+      }),
+      dict({
+        'length': 1613,
+        'length_tolerance': 0.03,
+        'name': dict({
+          'key': 'M',
+          'prefix': 'RNA',
+        }),
+        'rule': 'optional',
       }),
       dict({
         'length': 1291,

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -192,11 +192,18 @@ class TestSetPlan:
             == first_segment.name
         )
 
-    @pytest.mark.parametrize("accessions", [["MF062136", "MF062137"], ["MF062136"]])
+    @pytest.mark.parametrize(
+        ("initial_accessions", "new_accessions"),
+        [
+            (["MF062136", "MF062137"], ["MF062138"]),
+            (["MF062136"], ["MF062137", "MF062138"]),
+        ],
+    )
     def test_add_segments_to_plan_ok(
         self,
         precached_repo: Repo,
-        accessions: list[str],
+        initial_accessions: list[str],
+        new_accessions: list[str],
         snapshot: SnapshotAssertion,
     ):
         """Test the addition of segments to an OTU plan."""
@@ -204,7 +211,7 @@ class TestSetPlan:
             otu_before = create_otu_with_taxid(
                 precached_repo,
                 2164102,
-                accessions,
+                initial_accessions,
                 acronym="",
             )
 
@@ -217,10 +224,10 @@ class TestSetPlan:
                 precached_repo,
                 otu_before,
                 rule=SegmentRule.OPTIONAL,
-                accessions=["MF062138"],
+                accessions=new_accessions,
             )
 
-        assert len(new_segment_ids) == len(accessions)
+        assert len(new_segment_ids) == len(new_accessions)
 
         otu_after = precached_repo.get_otu(otu_before.id)
 

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -210,21 +210,23 @@ class TestSetPlan:
 
         original_plan = otu_before.plan
 
-        assert type(original_plan) is Plan
+        assert isinstance(original_plan, Plan)
 
         with precached_repo.lock():
-            expanded_plan = add_segments_to_plan(
+            new_segment_ids = add_segments_to_plan(
                 precached_repo,
                 otu_before,
                 rule=SegmentRule.OPTIONAL,
                 accessions=["MF062138"],
             )
 
-        assert len(expanded_plan.segments) == len(original_plan.segments) + 1
+        assert len(new_segment_ids) == len(accessions)
 
         otu_after = precached_repo.get_otu(otu_before.id)
 
-        assert otu_after.plan != otu_before.plan
+        assert new_segment_ids.issubset(otu_before.plan.segment_ids)
+
+        assert otu_after.plan.segment_ids.issubset(otu_before.plan.segment_ids)
 
         assert otu_after.plan.model_dump() == snapshot(exclude=props("id"))
 

--- a/tests/test_modify.py
+++ b/tests/test_modify.py
@@ -248,14 +248,13 @@ class TestSetPlan:
 
         assert otu_before.plan.monopartite
 
-        with pytest.raises(ValueError):
-            with scratch_repo.lock():
-                add_segments_to_plan(
-                    scratch_repo,
-                    otu_before,
-                    rule=SegmentRule.OPTIONAL,
-                    accessions=["NC_010620"],
-                )
+        with scratch_repo.lock():
+            assert not add_segments_to_plan(
+                scratch_repo,
+                otu_before,
+                rule=SegmentRule.OPTIONAL,
+                accessions=["NC_010620"],
+            )
 
     @pytest.mark.parametrize("tolerance", [0.05, 0.5, 1.0])
     def test_set_length_tolerances_ok(self, scratch_repo: Repo, tolerance: float):


### PR DESCRIPTION
* refactor: `add_segments_to_plan()` now returns `{UUID}` instead of `Plan | None`
* fix: `ref-builder otu extend-plan` no longer creates a nested transaction
* chore: `add_segments_to_plan()`: if not all requested segments can be created, return an empty set
* chore: deprecate `otu.modify.resize_monopartite_plan()`
* add `Plan.segment_ids` convenience property